### PR TITLE
HRQB 15 - Load static data from HR 

### DIFF
--- a/hrqb/tasks/libhr_employee_appointments.py
+++ b/hrqb/tasks/libhr_employee_appointments.py
@@ -1,0 +1,81 @@
+"""hrqb.tasks.libhr_employee_appointments"""
+
+import luigi  # type: ignore[import-untyped]
+import pandas as pd
+
+from hrqb.base.task import (
+    PandasPickleTask,
+    QuickbaseUpsertTask,
+)
+from hrqb.utils.quickbase import QBClient
+
+
+class ExtractLibHREmployeeAppointments(PandasPickleTask):
+    """Extract data from Library HR provided employee appointment data.
+
+    This task is expecting the CSV to be a local filepath.  Unlike other pipelines in this
+    client, this pipeline is rarely run, and is suitable for local, developer runs to load
+    data.
+    """
+
+    pipeline = luigi.Parameter()
+    stage = luigi.Parameter("Extract")
+    csv_filepath = luigi.Parameter()
+
+    def get_dataframe(self) -> pd.DataFrame:
+        return pd.read_csv(self.csv_filepath)
+
+
+class TransformLibHREmployeeAppointments(PandasPickleTask):
+    """Enrich CSV data with data from other QB tables."""
+
+    stage = luigi.Parameter("Transform")
+    csv_filepath = luigi.Parameter()
+
+    def requires(self) -> list[luigi.Task]:  # pragma: nocover
+        return [
+            ExtractLibHREmployeeAppointments(
+                pipeline=self.pipeline, csv_filepath=self.csv_filepath
+            )
+        ]
+
+    def get_dataframe(self) -> pd.DataFrame:
+        libhr_df = self.single_input_dataframe
+
+        # get Department Record IDs from Quickbase and merge with static data
+        qbclient = QBClient()
+        departments_df = qbclient.get_table_as_df(qbclient.get_table_id("Departments"))
+        libhr_df = libhr_df.merge(
+            departments_df[["Acronym", "Record ID#"]].rename(
+                columns={"Acronym": "Department", "Record ID#": "Related Department ID"}
+            ),
+            how="left",
+        )
+
+        fields = {
+            "MIT ID": "Related Employee MIT ID",
+            "Supervisor ID": "Related Supervisor MIT ID",
+            "Cost Object": "Cost Object",
+            "HC ID": "HC ID",
+            "Position ID": "Position ID",
+            "Related Department ID": "Related Department ID",
+        }
+        return libhr_df[fields.keys()].rename(columns=fields)
+
+
+class LoadLibHREmployeeAppointments(QuickbaseUpsertTask):
+    table_name = luigi.Parameter("LibHR Employee Appointments")
+    stage = luigi.Parameter("Load")
+    csv_filepath = luigi.Parameter()
+
+    @property
+    def merge_field(self) -> str | None:
+        """Explicitly merge on unique Position ID field."""
+        return "Position ID"
+
+    def requires(self) -> list[luigi.Task]:  # pragma: nocover
+        return [
+            TransformLibHREmployeeAppointments(
+                pipeline=self.pipeline, csv_filepath=self.csv_filepath
+            )
+        ]

--- a/hrqb/tasks/libhr_employee_appointments.py
+++ b/hrqb/tasks/libhr_employee_appointments.py
@@ -55,10 +55,14 @@ class TransformLibHREmployeeAppointments(PandasPickleTask):
         libhr_df = self.named_inputs["ExtractLibHREmployeeAppointments"].read()
         departments_df = self.named_inputs["ExtractQBDepartments"].read()
 
+        # normalize department acronym merge field
+        libhr_df["Department"] = libhr_df["Department"].str.upper()
+        departments_df["Department"] = departments_df["Acronym"].str.upper()
+
         # merge department data from quickbase with libhr data
         libhr_df = libhr_df.merge(  # type: ignore[union-attr]
-            departments_df[["Acronym", "Record ID#"]].rename(
-                columns={"Acronym": "Department", "Record ID#": "Related Department ID"}
+            departments_df[["Department", "Record ID#"]].rename(
+                columns={"Record ID#": "Related Department ID"}
             ),
             how="left",
         )

--- a/hrqb/tasks/pipelines.py
+++ b/hrqb/tasks/pipelines.py
@@ -14,3 +14,36 @@ class FullUpdate(HRQBPipelineTask):
         from hrqb.tasks.employees import LoadEmployees
 
         yield LoadEmployees(pipeline=self.pipeline_name)
+
+
+class UpdateLibHRData(HRQBPipelineTask):
+    """Pipeline to load Library HR employee appointment data from static CSV file.
+
+    This pipeline loads the table 'LibHR Employee Appointments', which contains
+    information known only by Library HR, that we cannot get from the data warehouse,
+    including:
+        - position HC ID (Headcount ID)
+        - position supervisor
+        - position library department
+        - position cost object
+
+    This Quickbase table is used by the 'Employee Appointments' table to fill in gaps from
+    warehouse data alone.  This pipeline is useful for initial loading and bulk changes,
+    but this table is primarily managed directly in Quickbase by HR staff.
+
+    This pipeline requires a 'csv_filepath' parameter is defined when running, e.g.
+        pipenv run hrqb --verbose /
+        pipeline -p UpdateLibHRData /
+        --pipeline-parameters=csv_filepath=<PATH TO CSV> /
+        run
+    """
+
+    csv_filepath = luigi.Parameter()
+
+    def requires(self) -> Iterator[luigi.Task]:  # pragma: no cover
+        from hrqb.tasks.libhr_employee_appointments import LoadLibHREmployeeAppointments
+
+        yield LoadLibHREmployeeAppointments(
+            pipeline=self.pipeline_name,
+            csv_filepath=self.csv_filepath,
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,6 +17,7 @@ from hrqb.base.task import PandasPickleTarget, QuickbaseUpsertTask
 from hrqb.tasks.employees import ExtractDWEmployees, TransformEmployees
 from hrqb.tasks.libhr_employee_appointments import (
     ExtractLibHREmployeeAppointments,
+    ExtractQBDepartments,
     LoadLibHREmployeeAppointments,
     TransformLibHREmployeeAppointments,
 )
@@ -529,10 +530,26 @@ def mocked_qbclient_departments_df():
 
 
 @pytest.fixture
+def task_extract_qb_departments(
+    pipeline_update_libhr_data,
+) -> ExtractQBDepartments:
+    return pipeline_update_libhr_data.get_task(ExtractQBDepartments)
+
+
+@pytest.fixture
+def task_extract_qb_departments_target(
+    task_extract_qb_departments, mocked_qbclient_departments_df
+):
+    task_extract_qb_departments.run()
+    return task_extract_qb_departments.target
+
+
+@pytest.fixture
 def task_transform_libhr_employee_appointments(
     mocked_qbclient_departments_df,
     pipeline_update_libhr_data,
     task_extract_libhr_employee_appointments_target,
+    task_extract_qb_departments_target,
 ) -> TransformLibHREmployeeAppointments:
     return pipeline_update_libhr_data.get_task(TransformLibHREmployeeAppointments)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,12 @@ from click.testing import CliRunner
 from hrqb.base import HRQBTask, QuickbaseTableTarget
 from hrqb.base.task import PandasPickleTarget, QuickbaseUpsertTask
 from hrqb.tasks.employees import ExtractDWEmployees, TransformEmployees
+from hrqb.tasks.libhr_employee_appointments import (
+    ExtractLibHREmployeeAppointments,
+    LoadLibHREmployeeAppointments,
+    TransformLibHREmployeeAppointments,
+)
+from hrqb.tasks.pipelines import UpdateLibHRData
 from hrqb.utils.data_warehouse import DWClient
 from hrqb.utils.quickbase import QBClient
 from tests.fixtures.tasks.extract import (
@@ -471,3 +477,68 @@ def task_extract_dw_employees_target(
 @pytest.fixture
 def task_transform_employees(all_tasks_pipeline_name):
     return TransformEmployees(pipeline=all_tasks_pipeline_name)
+
+
+@pytest.fixture
+def libhr_static_data_csv_filepath():
+    return "tests/fixtures/libhr_static_data.csv"
+
+
+@pytest.fixture
+def pipeline_update_libhr_data(libhr_static_data_csv_filepath):
+    return UpdateLibHRData(csv_filepath=libhr_static_data_csv_filepath)
+
+
+@pytest.fixture
+def task_extract_libhr_employee_appointments(
+    pipeline_update_libhr_data,
+) -> ExtractLibHREmployeeAppointments:
+    return pipeline_update_libhr_data.get_task(ExtractLibHREmployeeAppointments)
+
+
+@pytest.fixture
+def task_extract_libhr_employee_appointments_target(
+    task_extract_libhr_employee_appointments,
+):
+    task_extract_libhr_employee_appointments.run()
+    return task_extract_libhr_employee_appointments.target
+
+
+@pytest.fixture
+def mocked_qbclient_departments_df():
+    with mock.patch(
+        "hrqb.utils.quickbase.QBClient.get_table_as_df"
+    ) as mocked_get_table_df, mock.patch(
+        "hrqb.utils.quickbase.QBClient.get_table_id"
+    ) as _mocked_table_id:
+        mocked_get_table_df.return_value = pd.DataFrame(
+            [
+                {
+                    "Department": "Distinctive Collections",
+                    "Acronym": "DDC",
+                    "Record ID#": 35,
+                },
+                {
+                    "Department": "Information Technology Services",
+                    "Acronym": "ITS",
+                    "Record ID#": 40,
+                },
+            ]
+        )
+        yield mocked_get_table_df
+
+
+@pytest.fixture
+def task_transform_libhr_employee_appointments(
+    mocked_qbclient_departments_df,
+    pipeline_update_libhr_data,
+    task_extract_libhr_employee_appointments_target,
+) -> TransformLibHREmployeeAppointments:
+    return pipeline_update_libhr_data.get_task(TransformLibHREmployeeAppointments)
+
+
+@pytest.fixture
+def task_load_libhr_employee_appointments(
+    pipeline_update_libhr_data,
+) -> LoadLibHREmployeeAppointments:
+    return pipeline_update_libhr_data.get_task(LoadLibHREmployeeAppointments)

--- a/tests/fixtures/libhr_static_data.csv
+++ b/tests/fixtures/libhr_static_data.csv
@@ -1,0 +1,4 @@
+MIT ID,HC ID,Full Name,Position,Position ID,Employee Type,Supervisor ID,Supervisor Name,Cost Object,Department
+123456789,L-001,"Doe, John",Science Librarian,888888888,Admin Staff,444444444,"Smith, Fancy",555555555,DDC
+987654321,L-100,"Doe, Jane",Data Engineer,999999999,Admin Staff,444444444,"Smith, Fancy",555555555,ITS
+987654321,L-100,"Doe, Jane",DevOps Engineer,999999991,Admin Staff,444444444,"Smith, Fancy",555555555,BAD_ACRO

--- a/tests/tasks/test_libhr_employee_appointments.py
+++ b/tests/tasks/test_libhr_employee_appointments.py
@@ -15,9 +15,7 @@ def test_extract_libhr_employee_appointments_read_csv(
 
 
 def test_transform_libhr_employee_appointments_merge_departments(
-    mocked_qbclient_departments_df,
     task_transform_libhr_employee_appointments,
-    task_extract_dw_employees_target,
 ):
     new_df = task_transform_libhr_employee_appointments.get_dataframe()
     assert new_df.equals(

--- a/tests/tasks/test_libhr_employee_appointments.py
+++ b/tests/tasks/test_libhr_employee_appointments.py
@@ -1,0 +1,58 @@
+# ruff: noqa: PD901, PLR2004
+
+import numpy as np
+import pandas as pd
+
+
+def test_extract_libhr_employee_appointments_read_csv(
+    task_extract_libhr_employee_appointments,
+):
+    df = task_extract_libhr_employee_appointments.get_dataframe()
+    assert isinstance(df, pd.DataFrame)
+    assert len(df) == 3
+    assert df.iloc[0]["MIT ID"] == 123456789
+    assert df.iloc[0]["Supervisor ID"] == 444444444
+
+
+def test_transform_libhr_employee_appointments_merge_departments(
+    mocked_qbclient_departments_df,
+    task_transform_libhr_employee_appointments,
+    task_extract_dw_employees_target,
+):
+    new_df = task_transform_libhr_employee_appointments.get_dataframe()
+    assert new_df.equals(
+        pd.DataFrame(
+            [
+                {
+                    "Related Employee MIT ID": 123456789,
+                    "Related Supervisor MIT ID": 444444444,
+                    "Cost Object": 555555555,
+                    "HC ID": "L-001",
+                    "Position ID": 888888888,
+                    "Related Department ID": 35.0,
+                },
+                {
+                    "Related Employee MIT ID": 987654321,
+                    "Related Supervisor MIT ID": 444444444,
+                    "Cost Object": 555555555,
+                    "HC ID": "L-100",
+                    "Position ID": 999999999,
+                    "Related Department ID": 40.0,
+                },
+                {
+                    "Related Employee MIT ID": 987654321,
+                    "Related Supervisor MIT ID": 444444444,
+                    "Cost Object": 555555555,
+                    "HC ID": "L-100",
+                    "Position ID": 999999991,
+                    "Related Department ID": np.nan,
+                },
+            ]
+        )
+    )
+
+
+def test_load_libhr_employee_appointments_merge_field_set(
+    task_load_libhr_employee_appointments,
+):
+    assert task_load_libhr_employee_appointments.merge_field == "Position ID"


### PR DESCRIPTION
### Purpose and background context

This PR introduces a new pipeline `UpdateLibHRData`.  Unlike `FullUpdate`, this pipeline is anticipated to get run very infrequently, but is needed.  This pipeline will load static data provided by HR into a table called `LibHR Employee Appointments`.  This pipeline will be used for an initial load of data, and potentially for bulk updates requested by HR, but this table will **primarily be managed directly in Quickbase**.

### How can a reviewer manually see the effects of these changes?

Still in discussion with HR about credentials and access, so it may be some time before we have readily accessible ways to test run these pipelines for everyone.

That said, here is an example CLI command to invokes it, passing a parameter for a local CSV file:

```shell
pipenv run hrqb pipeline -p UpdateLibHRData \
-pp csv_filepath=output/headcount/QB-GH-May24.csv \
run
```

And the output:
```
├── COMPLETE: UpdateLibHRData(csv_filepath=output/headcount/QB-GH-May24.csv)
   ├── COMPLETE: LoadLibHREmployeeAppointments(pipeline=UpdateLibHRData, table_name=LibHR Employee Appointments, stage=Load, csv_filepath=output/headcount/QB-GH-May24.csv)
      ├── COMPLETE: TransformLibHREmployeeAppointments(pipeline=UpdateLibHRData, table_name=, stage=Transform, csv_filepath=output/headcount/QB-GH-May24.csv)
         ├── COMPLETE: ExtractLibHREmployeeAppointments(table_name=, pipeline=UpdateLibHRData, stage=Extract, csv_filepath=output/headcount/QB-GH-May24.csv)
         ├── COMPLETE: ExtractQBDepartments(table_name=, pipeline=UpdateLibHRData, stage=Extract)
```

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/HRQB-15

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes

