### PR TITLE
HRQB 28 - ETL tasks for Employee Leave

### DIFF
--- a/hrqb/tasks/employee_leave.py
+++ b/hrqb/tasks/employee_leave.py
@@ -1,0 +1,129 @@
+"""hrqb.tasks.employee_leaves"""
+
+# ruff: noqa: S324
+
+import hashlib
+
+import luigi  # type: ignore[import-untyped]
+import pandas as pd
+
+from hrqb.base.task import (
+    PandasPickleTask,
+    QuickbaseUpsertTask,
+    SQLQueryExtractTask,
+)
+from hrqb.utils import convert_oracle_bools_to_qb_bools, normalize_dataframe_dates
+
+
+class ExtractDWEmployeeLeave(SQLQueryExtractTask):
+    """Query Data Warehouse for employee leave data."""
+
+    stage = luigi.Parameter("Extract")
+
+    @property
+    def sql_file(self) -> str:
+        return "hrqb/tasks/sql/employee_leave.sql"
+
+
+class TransformEmployeeLeave(PandasPickleTask):
+
+    stage = luigi.Parameter("Transform")
+
+    def requires(self) -> list[luigi.Task]:
+        from hrqb.tasks.shared import ExtractQBEmployeeAppointments
+
+        return [
+            ExtractQBEmployeeAppointments(pipeline=self.pipeline),
+            ExtractDWEmployeeLeave(pipeline=self.pipeline),
+        ]
+
+    def get_dataframe(self) -> pd.DataFrame:
+        dw_leaves_df = self.named_inputs["ExtractDWEmployeeLeave"].read()
+        qb_emp_appts_df = self.named_inputs["ExtractQBEmployeeAppointments"].read()
+
+        qb_emp_appts_df = qb_emp_appts_df[["HR Appointment Key", "Record ID#"]].rename(
+            columns={
+                "HR Appointment Key": "hr_appt_key",
+                "Record ID#": "related_employee_appointment_id",
+            }
+        )
+        leaves_df = dw_leaves_df.merge(qb_emp_appts_df, how="left", on="hr_appt_key")
+
+        leaves_df = normalize_dataframe_dates(
+            leaves_df,
+            ["appt_begin_date", "appt_end_date", "absence_date"],
+        )
+
+        # WIP TODO: determine what data points from combination employee leave and
+        # employee appointments determine the field "Accrue Seniority".  For now,
+        # placeholder of blanket "Y" (true) until this is determined.
+        leaves_df["accrue_seniority"] = "Y"
+
+        leaves_df = convert_oracle_bools_to_qb_bools(
+            leaves_df, columns=["paid_leave", "accrue_seniority"]
+        )
+
+        # mint a unique MD5 hash based on leave data
+        leaves_df["key"] = leaves_df.apply(
+            lambda row: self._create_unique_key_from_leave_data(
+                row.mit_id,
+                row.absence_date,
+                row.absence_type,
+                row.actual_absence_hours,
+            ),
+            axis=1,
+        )
+
+        fields = {
+            "key": "Key",
+            "mit_id": "MIT ID",
+            "absence_date": "Leave Date",
+            "absence_type": "Related Leave Type",
+            "actual_absence_hours": "Duration Hours",
+            "actual_absence_days": "Duration Days",
+            "paid_leave": "Paid Leave",
+            "accrue_seniority": "Accrue Seniority",
+            "related_employee_appointment_id": "Related Employee Appointment",
+        }
+        return leaves_df[fields.keys()].rename(columns=fields)
+
+    @staticmethod
+    def _create_unique_key_from_leave_data(
+        mit_id: str,
+        absence_date: str,
+        absence_type: str,
+        absence_hours: str | float,
+    ) -> str:
+        """Create MD5 hash based specific leave data."""
+        data_string = "|".join(
+            [
+                mit_id,
+                absence_date,
+                absence_type,
+                str(absence_hours),
+            ]
+        ).encode()
+        return hashlib.md5(data_string).hexdigest()
+
+
+class LoadEmployeeLeave(QuickbaseUpsertTask):
+
+    stage = luigi.Parameter("Load")
+    table_name = "Employee Leave"
+
+    def requires(self) -> list[luigi.Task]:  # pragma: nocover
+
+        from hrqb.tasks.employee_leave_types import LoadEmployeeLeaveTypes
+
+        return [
+            LoadEmployeeLeaveTypes(pipeline=self.pipeline),
+            TransformEmployeeLeave(pipeline=self.pipeline),
+        ]
+
+    @property
+    def merge_field(self) -> str | None:
+        return "Key"
+
+    @property
+    def input_task_to_load(self) -> str:
+        return "TransformEmployeeLeave"

--- a/hrqb/tasks/employee_leave_types.py
+++ b/hrqb/tasks/employee_leave_types.py
@@ -1,0 +1,39 @@
+"""hrqb.tasks.employee_leave_types"""
+
+import luigi  # type: ignore[import-untyped]
+import pandas as pd
+
+from hrqb.base.task import PandasPickleTask, QuickbaseUpsertTask
+from hrqb.tasks.employee_leave import TransformEmployeeLeave
+
+
+class TransformEmployeeLeaveTypes(PandasPickleTask):
+    """Get unique employee leave types from employee leave data.
+
+    Required fields:
+        - Leave Type: lookup table value
+        - Paid Leave: [Yes, No]
+        - Accrue Seniority: [Yes, No, N/A]
+    """
+
+    stage = luigi.Parameter("Transform")
+
+    def requires(self) -> list[luigi.Task]:  # pragma: nocover
+        return [TransformEmployeeLeave(pipeline=self.pipeline)]
+
+    def get_dataframe(self) -> pd.DataFrame:
+        leaves_df = self.single_input_dataframe
+        fields = {
+            "Related Leave Type": "Leave Type",
+            "Paid Leave": "Paid Leave",
+            "Accrue Seniority": "Accrue Seniority",
+        }
+        return leaves_df[fields.keys()].drop_duplicates().rename(columns=fields)
+
+
+class LoadEmployeeLeaveTypes(QuickbaseUpsertTask):
+    table_name = luigi.Parameter("Leave Types")
+    stage = luigi.Parameter("Load")
+
+    def requires(self) -> list[luigi.Task]:  # pragma: nocover
+        return [TransformEmployeeLeaveTypes(pipeline=self.pipeline)]

--- a/hrqb/tasks/pipelines.py
+++ b/hrqb/tasks/pipelines.py
@@ -12,12 +12,14 @@ class FullUpdate(HRQBPipelineTask):
 
     def requires(self) -> Iterator[luigi.Task]:  # pragma: no cover
         from hrqb.tasks.employee_appointments import LoadEmployeeAppointments
+        from hrqb.tasks.employee_leave import LoadEmployeeLeave
         from hrqb.tasks.employee_salary_history import LoadEmployeeSalaryHistory
         from hrqb.tasks.employees import LoadEmployees
 
         yield LoadEmployees(pipeline=self.pipeline_name)
         yield LoadEmployeeAppointments(pipeline=self.pipeline_name)
         yield LoadEmployeeSalaryHistory(pipeline=self.pipeline_name)
+        yield LoadEmployeeLeave(pipeline=self.pipeline_name)
 
 
 class UpdateLibHRData(HRQBPipelineTask):

--- a/hrqb/tasks/sql/employee_leave.sql
+++ b/hrqb/tasks/sql/employee_leave.sql
@@ -1,0 +1,28 @@
+/*
+Query for Employee Leaves.
+
+CHANGELOG
+    - 2024-05-13 Query created and added
+*/
+
+select distinct
+    appt.MIT_ID,
+    appt.APPT_BEGIN_DATE,
+    appt.APPT_END_DATE,
+    appt.HR_APPT_KEY,
+    abse.ABSENCE_DATE,
+    at.ABSENCE_TYPE,
+    at.ABSENCE_TYPE_CODE,
+    abse.ACTUAL_ABSENCE_HOURS,
+    abse.ACTUAL_ABSENCE_DAYS,
+    case
+        when at.ABSENCE_TYPE = 'Leave Without Pay' then 'N'
+        else 'Y'
+    end as PAID_LEAVE
+from HR_ABSENCE_DETAIL abse
+inner join HR_APPOINTMENT_DETAIL appt on abse.MIT_ID = appt.MIT_ID
+inner join HR_ABSENCE_TYPE at on at.HR_ABSENCE_TYPE_KEY = abse.HR_ABSENCE_TYPE_KEY where (
+    appt.APPT_END_DATE >= TO_DATE('2019-01-01', 'YYYY-MM-DD')
+    and abse.ABSENCE_DATE between appt.APPT_BEGIN_DATE and appt.APPT_END_DATE
+)
+order by appt.MIT_ID, abse.ABSENCE_DATE

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -798,3 +798,63 @@ def task_transform_employee_salary_change_types_complete(
     task = TransformSalaryChangeTypes(pipeline=all_tasks_pipeline_name)
     task.run()
     return task
+
+
+@pytest.fixture
+def task_extract_dw_employee_leave_complete(all_tasks_pipeline_name):
+    from hrqb.tasks.employee_leave import ExtractDWEmployeeLeave
+
+    task = ExtractDWEmployeeLeave(pipeline=all_tasks_pipeline_name)
+    task.target.write(
+        pd.DataFrame(
+            [
+                {
+                    "mit_id": "123456789",
+                    "appt_begin_date": Timestamp("2010-01-01 00:00:00"),
+                    "appt_end_date": datetime.datetime(2011, 12, 1, 0, 0),
+                    "hr_appt_key": 123,
+                    "absence_date": Timestamp("2010-07-01 00:00:00"),
+                    "absence_type": "Vacation",
+                    "absence_type_code": "VACA",
+                    "actual_absence_hours": 8.0,
+                    "actual_absence_days": 1.0,
+                    "paid_leave": "Y",
+                }
+            ]
+        )
+    )
+    return task
+
+
+@pytest.fixture
+def task_transform_employee_leave_complete(
+    all_tasks_pipeline_name,
+    task_extract_dw_employee_leave_complete,
+    task_shared_extract_qb_employee_appointments_complete,
+):
+    from hrqb.tasks.employee_leave import TransformEmployeeLeave
+
+    task = TransformEmployeeLeave(pipeline=all_tasks_pipeline_name)
+    task.run()
+    return task
+
+
+@pytest.fixture
+def task_load_employee_leave(
+    all_tasks_pipeline_name, task_transform_employee_leave_complete
+):
+    from hrqb.tasks.employee_leave import LoadEmployeeLeave
+
+    return LoadEmployeeLeave(pipeline=all_tasks_pipeline_name)
+
+
+@pytest.fixture
+def task_transform_employee_leave_types_complete(
+    all_tasks_pipeline_name,
+    task_transform_employee_leave_complete,
+):
+    from hrqb.tasks.employee_leave_types import TransformEmployeeLeaveTypes
+
+    task = TransformEmployeeLeaveTypes(pipeline=all_tasks_pipeline_name)
+    task.run()
+    return task

--- a/tests/tasks/test_employee_leave.py
+++ b/tests/tasks/test_employee_leave.py
@@ -1,0 +1,64 @@
+# ruff: noqa: PLR2004, PD901, SLF001
+
+
+def test_extract_dw_employee_leave_load_sql_query(
+    task_extract_dw_employee_leave_complete,
+):
+    assert (
+        task_extract_dw_employee_leave_complete.sql_file
+        == "hrqb/tasks/sql/employee_leave.sql"
+    )
+    assert task_extract_dw_employee_leave_complete.sql_query is not None
+
+
+def test_task_transform_employee_leave_employee_appointments_merge_success(
+    task_transform_employee_leave_complete,
+):
+    row = task_transform_employee_leave_complete.get_dataframe().iloc[0]
+    assert row["Related Employee Appointment"] == 12000
+
+
+def test_task_transform_employee_leave_oracle_bools_converted(
+    task_transform_employee_leave_complete,
+):
+    row = task_transform_employee_leave_complete.get_dataframe().iloc[0]
+    assert row["Paid Leave"] == "Yes"
+    assert row["Accrue Seniority"] == "Yes"
+
+
+def test_task_transform_employee_leave_create_key_from_md5_of_leave_data(
+    task_transform_employee_leave_complete,
+):
+    assert (
+        task_transform_employee_leave_complete._create_unique_key_from_leave_data(
+            "123456789", "2010-07-01", "Vacation", "8.0"
+        )
+        == "ee9af1a7908735241aeb5c228e2e00fa"
+    )
+    assert (
+        task_transform_employee_leave_complete._create_unique_key_from_leave_data(
+            "123456789", "2010-07-01", "Vacation", "None"
+        )
+        == "767d2672e2e6b38a7c65f0ea2f799067"
+    )
+
+
+def test_task_transform_employee_leave_key_expected_from_row_data(
+    task_transform_employee_leave_complete,
+):
+    row = task_transform_employee_leave_complete.get_dataframe().iloc[0]
+    assert row[
+        "Key"
+    ] == task_transform_employee_leave_complete._create_unique_key_from_leave_data(
+        row["MIT ID"],
+        row["Leave Date"],
+        row["Related Leave Type"],
+        str(row["Duration Hours"]),
+    )
+
+
+def test_task_load_employee_salary_history_explicit_properties(
+    task_load_employee_leave,
+):
+    assert task_load_employee_leave.merge_field == "Key"
+    assert task_load_employee_leave.input_task_to_load == "TransformEmployeeLeave"

--- a/tests/tasks/test_employee_salary_history.py
+++ b/tests/tasks/test_employee_salary_history.py
@@ -11,18 +11,6 @@ def test_extract_dw_employee_salary_history_load_sql_query(
     assert task_extract_dw_employee_salary_history_complete.sql_query is not None
 
 
-def test_task_extract_qb_employee_appointments_complete_has_required_fields(
-    task_shared_extract_qb_employee_appointments_complete,
-):
-    required_columns = [
-        "Record ID#",
-        "HR Appointment Key",
-    ]
-    assert set(required_columns).issubset(
-        set(task_shared_extract_qb_employee_appointments_complete.target.read().columns)
-    )
-
-
 def test_task_transform_employee_salary_history_employee_appointments_merge_success(
     task_transform_employee_salary_history_complete,
 ):

--- a/tests/tasks/test_lookup_tables.py
+++ b/tests/tasks/test_lookup_tables.py
@@ -26,3 +26,11 @@ def test_task_transform_employee_salary_change_types_required_fields(
     assert {"Salary Change Type"} == set(
         task_transform_employee_salary_change_types_complete.get_dataframe().columns
     )
+
+
+def test_task_transform_employee_leave_types_required_fields(
+    task_transform_employee_leave_types_complete,
+):
+    assert {"Leave Type", "Paid Leave", "Accrue Seniority"} == set(
+        task_transform_employee_leave_types_complete.get_dataframe().columns
+    )

--- a/tests/tasks/test_shared.py
+++ b/tests/tasks/test_shared.py
@@ -1,0 +1,13 @@
+# ruff: noqa: PLR2004, PD901
+
+
+def test_task_extract_qb_employee_appointments_complete_has_required_fields(
+    task_shared_extract_qb_employee_appointments_complete,
+):
+    required_columns = [
+        "Record ID#",
+        "HR Appointment Key",
+    ]
+    assert set(required_columns).issubset(
+        set(task_shared_extract_qb_employee_appointments_complete.target.read().columns)
+    )


### PR DESCRIPTION
### Purpose and background context

Adds ETL tasks for `Employee Leave` and `Employee Leave Types`.

This is one of the last PRs for primary tables in Quickbase that this application is responsible for loading, sitting alongside `Employees`, `Employee Appointments`, `Employee Salary History`, and their related lookup tables.

With this leave data now getting loaded as well, development will likely shift towads improved observability, data integrity tests, and adjustments as required from stakeholders to data flowing through these established ETL pipelines.

### How can a reviewer manually see the effects of these changes?

Running the `status` command for the pipeline task `LoadEmployeeLeave` reveals the interconnected nature of this task (and others):

```
├── COMPLETE: LoadEmployeeLeave(...)   <----------------------
  ├── COMPLETE: LoadEmployeeLeaveTypes(...)  <----------------------
     ├── COMPLETE: TransformEmployeeLeaveTypes(...)  <----------------------
        ├── COMPLETE: TransformEmployeeLeave(...)  <----------------------
           ├── COMPLETE: ExtractQBEmployeeAppointments(...)
              ├── COMPLETE: LoadEmployeeAppointments(...)
                 ├── COMPLETE: LoadEmployeeTypes(...)
                    ├── COMPLETE: TransformEmployeeTypes(...)
                       ├── COMPLETE: ExtractDWEmployeeAppointments(...)
                 ├── COMPLETE: LoadJobTitles(...)
                    ├── COMPLETE: TransformUniqueJobTitles(...)
                       ├── COMPLETE: ExtractDWEmployeeAppointments(...)
                 ├── COMPLETE: LoadPositionTitles(...)
                    ├── COMPLETE: TransformUniquePositionTitles(...)
                       ├── COMPLETE: ExtractDWEmployeeAppointments(...)
                 ├── COMPLETE: TransformEmployeeAppointments(...)
                    ├── COMPLETE: ExtractDWEmployeeAppointments(...)
                    ├── COMPLETE: ExtractQBLibHREmployeeAppointments(...)
                    ├── COMPLETE: ExtractQBDepartments(...)
           ├── COMPLETE: ExtractDWEmployeeLeave(...)
  ├── COMPLETE: TransformEmployeeLeave(...)  <----------------------
     ├── COMPLETE: ExtractQBEmployeeAppointments(...)  
        ├── COMPLETE: LoadEmployeeAppointments(...)
           ├── COMPLETE: LoadEmployeeTypes(...)
              ├── COMPLETE: TransformEmployeeTypes(...)
                 ├── COMPLETE: ExtractDWEmployeeAppointments(...)
           ├── COMPLETE: LoadJobTitles(...)
              ├── COMPLETE: TransformUniqueJobTitles(...)
                 ├── COMPLETE: ExtractDWEmployeeAppointments(...)
           ├── COMPLETE: LoadPositionTitles(...)
              ├── COMPLETE: TransformUniquePositionTitles(...)
                 ├── COMPLETE: ExtractDWEmployeeAppointments(...)
           ├── COMPLETE: TransformEmployeeAppointments(...)
              ├── COMPLETE: ExtractDWEmployeeAppointments(...)
              ├── COMPLETE: ExtractQBLibHREmployeeAppointments(...)
              ├── COMPLETE: ExtractQBDepartments(...)
     ├── COMPLETE: ExtractDWEmployeeLeave(...)  <----------------------
```

Similar to tests for loading other QB tables, tests reveal some patterns of data fetched and transformed, and inter-dependencies on other tasks.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/HRQB-28

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes

