### PR TITLE
HRQB 32 - Default small response on Quickbase upsert

### DIFF
--- a/hrqb/utils/quickbase.py
+++ b/hrqb/utils/quickbase.py
@@ -158,6 +158,7 @@ class QBClient:
         table_id: str,
         records: list[dict],
         merge_field: str | None = None,
+        return_fields: bool = False,  # noqa: FBT001, FBT002
     ) -> dict:
         """Prepare an API payload for upsert.
 
@@ -176,7 +177,7 @@ class QBClient:
         upsert_payload = {
             "to": table_id,
             "data": mapped_records,
-            "fieldsToReturn": list(field_map.values()),
+            "fieldsToReturn": list(field_map.values()) if return_fields else [],
         }
         if merge_field:
             upsert_payload["mergeFieldId"] = field_map[merge_field]


### PR DESCRIPTION
### Purpose and background context

It was determined that large upserts could result in memory pressure due to the response from quickbase from an API upsert which returned every field, for every record, in the response.

Ultimately, this level of grain is not needed for parsing the success/failure of upserts, so it now defaults to explicitly not requesting any fields to return.  If needed, fields can still be requested via the method `QBClient.prepare_upsert_payload(..., return_fields=True)`

Example with fields (only three records with few fields, but `EmployeeLeave` for example upserts 20k+ rows, with dozens of fields, so this grows considerably):
```json
{
  "data": [
    {
      "1": {
        "value": "Green"
      },
      "2": {
        "value": 42
      }
    },
    {
      "1": {
        "value": "Red"
      },
      "2": {
        "value": 101
      }
    },
    {
      "1": {
        "value": "Blue"
      },
      "2": {
        "value": 999
      }
    }
  ],
  "metadata": {
    "createdRecordIds": [
      11,
      12
    ],
    "totalNumberOfRecordsProcessed": 3,
    "unchangedRecordIds": [],
    "updatedRecordIds": [
      1
    ]
  }
}
```

Example without fields:
```json
{
  "data": [],  # <------ note empty data property
  "metadata": {
    "createdRecordIds": [
      11,
      12
    ],
    "totalNumberOfRecordsProcessed": 3,
    "unchangedRecordIds": [],
    "updatedRecordIds": [
      1
    ]
  }
}
```

How this addresses that need:
* Add return_fields parameter to preparing upsert payload

### How can a reviewer manually see the effects of these changes?

Not readily testable without credentials or deployed instances.  But monitoring `docker stats` when running locally revealed a max of about 350mb memory used, where before was around 1.2gb.

In AWS Stage environment, here was the run that failed:
<img width="1032" alt="Screenshot 2024-06-12 at 1 52 46 PM" src="https://github.com/MITLibraries/hrqb-client/assets/1753087/74429aaf-d690-45d4-8ab4-cb121f800ddd">


And here is the same run parameters in Stage with the updates:
<img width="1036" alt="Screenshot 2024-06-12 at 2 28 38 PM" src="https://github.com/MITLibraries/hrqb-client/assets/1753087/c55f7f52-7baa-46cf-bf99-3aabe5b31460">
- note that while memory increases, it's only around 20% mark of 512mb on completion


### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/HRQB-32

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes

