### PR TITLE
Mint MD5 hash values for Key field

### DIFF
--- a/hrqb/utils/__init__.py
+++ b/hrqb/utils/__init__.py
@@ -1,6 +1,7 @@
 """hrqb.utils"""
 
 import datetime
+import hashlib
 import logging
 
 import click
@@ -60,3 +61,15 @@ def us_state_abbreviation_to_name(abbreviation: str | None) -> str | None:
     if state:
         return state.name
     return None
+
+
+def md5_hash_from_values(values: list[str]) -> str:
+    """Create an MD5 hash from an ordered list of values.
+
+    This function is used by some Transform tasks to mint a deterministic, unique value
+    that can be used as merge fields in Quickbase during upserts.
+
+    NOTE: the order of values in the provided list will affect the MD5 hash created.
+    """
+    data_string = "|".join(values).encode()
+    return hashlib.md5(data_string).hexdigest()  # noqa: S324

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -729,7 +729,7 @@ def task_extract_dw_employee_salary_history_complete(all_tasks_pipeline_name):
                     "mit_id": "123456789",
                     "job_id": "123456789",
                     "position_id": "987654321",
-                    "start_date": Timestamp("2010-01-01 00:00:00"),
+                    "start_date": Timestamp("2010-07-01 00:00:00"),
                     "end_date": datetime.datetime(2011, 12, 1, 0, 0),
                     "hr_personnel_action_type_key": "CS01",
                     "hr_personnel_action": "Annual Salary Review",
@@ -760,6 +760,9 @@ def task_shared_extract_qb_employee_appointments_complete(all_tasks_pipeline_nam
                 {
                     "Record ID#": 12000,
                     "HR Appointment Key": 123.0,
+                    "Position ID": "987654321",
+                    "Begin Date": "2010-01-01",
+                    "End Date": "2011-12-01",
                 }
             ]
         )

--- a/tests/tasks/test_employee_appointments.py
+++ b/tests/tasks/test_employee_appointments.py
@@ -1,5 +1,7 @@
 # ruff: noqa: PLR2004, PD901
 
+from hrqb.utils import md5_hash_from_values
+
 
 def test_extract_dw_employees_load_sql_query(
     task_extract_dw_employee_appointment_complete,
@@ -78,14 +80,29 @@ def test_task_transform_employee_appointments_returns_required_load_fields(
         "Union Name",
         "Term or Permanent",
         "Benefits Group Type",
+        "Key",
     } == set(df.columns)
 
 
 def test_task_load_employee_appointments_explicit_properties(
     task_load_employee_appointments,
 ):
-    assert task_load_employee_appointments.merge_field == "HR Appointment Key"
+    assert task_load_employee_appointments.merge_field == "Key"
     assert (
         task_load_employee_appointments.input_task_to_load
         == "TransformEmployeeAppointments"
+    )
+
+
+def test_task_transform_employee_appointments_key_expected_from_row_data(
+    task_transform_employee_appointments_complete,
+):
+    row = task_transform_employee_appointments_complete.get_dataframe().iloc[0]
+    assert row["Key"] == md5_hash_from_values(
+        [
+            row["MIT ID"],
+            row["Position ID"],
+            row["Begin Date"],
+            row["End Date"],
+        ]
     )

--- a/tests/tasks/test_employee_leave.py
+++ b/tests/tasks/test_employee_leave.py
@@ -1,5 +1,7 @@
 # ruff: noqa: PLR2004, PD901, SLF001
 
+from hrqb.utils import md5_hash_from_values
+
 
 def test_extract_dw_employee_leave_load_sql_query(
     task_extract_dw_employee_leave_complete,
@@ -26,34 +28,17 @@ def test_task_transform_employee_leave_oracle_bools_converted(
     assert row["Accrue Seniority"] == "Yes"
 
 
-def test_task_transform_employee_leave_create_key_from_md5_of_leave_data(
-    task_transform_employee_leave_complete,
-):
-    assert (
-        task_transform_employee_leave_complete._create_unique_key_from_leave_data(
-            "123456789", "2010-07-01", "Vacation", "8.0"
-        )
-        == "ee9af1a7908735241aeb5c228e2e00fa"
-    )
-    assert (
-        task_transform_employee_leave_complete._create_unique_key_from_leave_data(
-            "123456789", "2010-07-01", "Vacation", "None"
-        )
-        == "767d2672e2e6b38a7c65f0ea2f799067"
-    )
-
-
 def test_task_transform_employee_leave_key_expected_from_row_data(
     task_transform_employee_leave_complete,
 ):
     row = task_transform_employee_leave_complete.get_dataframe().iloc[0]
-    assert row[
-        "Key"
-    ] == task_transform_employee_leave_complete._create_unique_key_from_leave_data(
-        row["MIT ID"],
-        row["Leave Date"],
-        row["Related Leave Type"],
-        str(row["Duration Hours"]),
+    assert row["Key"] == md5_hash_from_values(
+        [
+            row["MIT ID"],
+            row["Leave Date"],
+            row["Related Leave Type"],
+            str(row["Duration Hours"]),
+        ]
     )
 
 

--- a/tests/tasks/test_employee_salary_history.py
+++ b/tests/tasks/test_employee_salary_history.py
@@ -1,5 +1,7 @@
 # ruff: noqa: PLR2004, PD901
 
+from hrqb.utils import md5_hash_from_values
+
 
 def test_extract_dw_employee_salary_history_load_sql_query(
     task_extract_dw_employee_salary_history_complete,
@@ -29,11 +31,32 @@ def test_task_transform_employee_salary_history_efforts_are_percents(
 def test_task_load_employee_salary_history_explicit_properties(
     task_load_employee_salary_history_complete,
 ):
-    assert (
-        task_load_employee_salary_history_complete.merge_field
-        == "HR Appointment Transaction Key"
-    )
+    assert task_load_employee_salary_history_complete.merge_field == "Key"
     assert (
         task_load_employee_salary_history_complete.input_task_to_load
         == "TransformEmployeeSalaryHistory"
+    )
+
+
+def test_task_transform_employee_salary_history_key_expected_from_input_data(
+    task_transform_employee_salary_history_complete,
+    task_shared_extract_qb_employee_appointments_complete,
+):
+    # NOTE: for this test, need to manually get part of the employee appointment data
+    #   that this transform is using when generating the unique MD5 Key field value
+    qb_emp_appt_row = (
+        task_shared_extract_qb_employee_appointments_complete.target.read().iloc[0]
+    )
+    emp_salary_row = task_transform_employee_salary_history_complete.get_dataframe().iloc[
+        0
+    ]
+    assert emp_salary_row["Key"] == md5_hash_from_values(
+        [
+            emp_salary_row["MIT ID"],
+            qb_emp_appt_row["Position ID"],
+            qb_emp_appt_row["Begin Date"],
+            qb_emp_appt_row["End Date"],
+            emp_salary_row["Start Date"],
+            emp_salary_row["End Date"],
+        ]
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,11 +4,13 @@ import datetime
 
 import numpy as np
 import pandas as pd
+import pytest
 from freezegun import freeze_time
 
 from hrqb.utils import (
     click_argument_to_dict,
     convert_oracle_bools_to_qb_bools,
+    md5_hash_from_values,
     normalize_dataframe_dates,
     normalize_date,
     today_date,
@@ -113,3 +115,26 @@ def test_convert_oracle_bools_to_qb_bools_success():
             ]
         )
     )
+
+
+def test_md5_hash_from_values_gives_expected_results():
+    assert md5_hash_from_values(["a", "b", "c"]) == "2e077b3ec5932ac3cf914ebdf242b4ee"
+
+
+def test_md5_hash_from_values_order_of_strings_different_results():
+    assert md5_hash_from_values(["a", "b"]) != md5_hash_from_values(["b", "a"])
+
+
+def test_md5_hash_from_values_raise_error_for_non_string_value():
+    with pytest.raises(TypeError, match="NoneType found"):
+        md5_hash_from_values(["a", "b", None])
+    with pytest.raises(TypeError, match="int found"):
+        md5_hash_from_values(["a", "b", 42])
+    with pytest.raises(TypeError, match="datetime found"):
+        md5_hash_from_values(
+            [
+                "a",
+                "b",
+                datetime.datetime(2000, 1, 1, tzinfo=datetime.UTC),
+            ]
+        )


### PR DESCRIPTION
### Purpose and background context

It was determined that columns used from the data warehouse, expected to be enduringly the same and unique, were changing across warehouse runs.  These values were used for Quickbase merge fields, but this would not work if the values changed.

Values for tables `Employee Appointments`, `Employee Salary History`, and `Employee Leave` were needed that uniquely identified the record/row, **and** would not change over time from warehouse runs.

The solution was to follow a pattern already established in `Employee Leave` to create an MD5 hash of record values that are known to uniquely identify a record.

For example, the following is  the code that mints an MD5 hash for `Employee Appointments`:
```python
emp_appts_df["key"] = emp_appts_df.apply(
            lambda row: md5_hash_from_values(
                [
                    row.mit_id,
                    row.position_id,
                    row.appt_begin_date,
                    row.appt_end_date,
                ]
            ),
            axis=1,
        )
```

### How can a reviewer manually see the effects of these changes?

New tests demonstrate how the utility function `md5_hash_from_values()` creates an MD5 hash from a list of strings.  Each Transform task for these tables utilizes this to set a `Key` field (naming convention from Quickbase) from a list of values.  There are tests ([example](https://github.com/MITLibraries/hrqb-client/pull/63), [example](https://github.com/MITLibraries/hrqb-client/pull/63/files#diff-260cf8b13f4efa8a193455f2e744008f6124140071150436a72720eb9f0c4e9bR41-R62), [example](https://github.com/MITLibraries/hrqb-client/pull/63/files#diff-fc33a6395ec39699f5a3ab10a0604289f177b2f837c1b92391f3966f44b4bb0dR31-R42)) for these transforms that show the value of the `Key` field is expected given the input row data.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/HRQB-36

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes

