### PR TITLE
HRQB 34 - Add base salary change percent

### DIFF
--- a/hrqb/tasks/employee_salary_history.py
+++ b/hrqb/tasks/employee_salary_history.py
@@ -30,23 +30,9 @@ class TransformEmployeeSalaryHistory(PandasPickleTask):
 
     def get_dataframe(self) -> pd.DataFrame:
         dw_salary_df = self.named_inputs["ExtractDWEmployeeSalaryHistory"].read()
-        qb_emp_appts_df = self.named_inputs["ExtractQBEmployeeAppointments"].read()
 
         # merge with employee appointment data for QB appointment record identifier
-        qb_emp_appts_df = qb_emp_appts_df[
-            [
-                "Record ID#",
-                "HR Appointment Key",
-                "Begin Date",
-                "End Date",
-            ]
-        ].rename(
-            columns={
-                "Record ID#": "related_employee_appointment_id",
-                "Begin Date": "appointment_begin_date",
-                "End Date": "appointment_end_date",
-            }
-        )
+        qb_emp_appts_df = self._get_employee_appointments()
         salary_df = dw_salary_df.merge(
             qb_emp_appts_df,
             how="left",
@@ -62,6 +48,9 @@ class TransformEmployeeSalaryHistory(PandasPickleTask):
         # convert efforts to percentages
         salary_df["original_effort"] = salary_df["original_effort"] / 100.0
         salary_df["temp_effort"] = salary_df["temp_effort"] / 100.0
+
+        # set base salary change percentage from previous record, for same position
+        salary_df = self._set_base_salary_change_percent(salary_df)
 
         # mint a unique, deterministic value for the merge "Key" field
         salary_df["key"] = salary_df.apply(
@@ -90,12 +79,64 @@ class TransformEmployeeSalaryHistory(PandasPickleTask):
             "original_base_amount": "Base Salary",
             "original_hourly_rate": "Hourly",
             "original_effort": "Effort %",
+            "base_change_percent": "Salary Change %",
             "temp_change_base_amount": "Temp Base Salary",
             "temp_change_hourly_rate": "Temp Hourly",
             "temp_effort": "Temp Effort %",
             "key": "Key",
         }
         return salary_df[fields.keys()].rename(columns=fields)
+
+    def _get_employee_appointments(self) -> pd.DataFrame:
+        qb_emp_appts_df = self.named_inputs["ExtractQBEmployeeAppointments"].read()
+        return qb_emp_appts_df[
+            [
+                "Record ID#",
+                "HR Appointment Key",
+                "Begin Date",
+                "End Date",
+            ]
+        ].rename(
+            columns={
+                "Record ID#": "related_employee_appointment_id",
+                "Begin Date": "appointment_begin_date",
+                "End Date": "appointment_end_date",
+            }
+        )
+
+    def _set_base_salary_change_percent(self, salary_df: pd.DataFrame) -> pd.DataFrame:
+        """Create column with percentage change between sequential salaries.
+
+        This method:
+            1. sorts by appointment MIT ID and appointment dates
+            2. groups the salary dataframe by MIT ID and unique appointment identifier
+            3. select the base salary from the PREVIOUS salary
+            4. calculates percentage change
+        """
+        new_salary_df = salary_df.copy()
+        new_salary_df["previous_base_amount"] = (
+            new_salary_df.sort_values(
+                [
+                    "mit_id",
+                    "appointment_begin_date",
+                    "appointment_end_date",
+                ]
+            )
+            .groupby(["mit_id", "hr_appt_key"])["original_base_amount"]
+            .shift(1)
+        )
+        new_salary_df["base_change_percent"] = round(
+            (
+                new_salary_df["original_base_amount"]
+                / new_salary_df["previous_base_amount"]
+                - 1.0
+            ),
+            3,
+        )
+        new_salary_df["base_change_percent"] = new_salary_df["base_change_percent"].where(
+            new_salary_df["previous_base_amount"].notna(), 0.0
+        )
+        return new_salary_df
 
 
 class LoadEmployeeSalaryHistory(QuickbaseUpsertTask):


### PR DESCRIPTION
### Purpose and background context

HR shared that it would be helpful to have the base salary change as a percentage between salary adjustments.

How this addresses that need:
* New column `Salary Change %` added to `TransformEmployeeSalaryHistory` task output
* Percentage calculated by:
  * grouping salary changes by position
  * populating previous salary for that position via sliding window (`.shift()` in pandas)
  * calculating the salary change percent from these two values

### How can a reviewer manually see the effects of these changes?

The new test [`test_task_transform_employee_salary_history_set_base_change_percent`](https://github.com/MITLibraries/hrqb-client/pull/64/files#diff-260cf8b13f4efa8a193455f2e744008f6124140071150436a72720eb9f0c4e9bR68-R114) demonstrates how the change in salary is calculated.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
YES: base salary now present in `Employee Salary History` Quickbase table

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/HRQB-34

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes

