### PR TITLE
HRQB 29 - Improve Quickbase upsert reporting

### DIFF
--- a/hrqb/base/task.py
+++ b/hrqb/base/task.py
@@ -215,6 +215,7 @@ class QuickbaseUpsertTask(HRQBTask):
 
     @property
     def parse_upsert_counts(self) -> dict | None:
+        """Parse results of upsert via QBClient method, if target data exists from run."""
         if self.target.exists():
             return QBClient.parse_upsert_results(self.target.read())
         return None

--- a/hrqb/base/task.py
+++ b/hrqb/base/task.py
@@ -1,10 +1,8 @@
 """hrqb.base.task"""
 
-import json
 import logging
 import os
 from abc import abstractmethod
-from collections import defaultdict
 from collections.abc import Iterator
 from typing import Literal
 
@@ -19,6 +17,9 @@ from hrqb.utils.quickbase import QBClient
 
 logger = logging.getLogger(__name__)
 
+successful_tasks = []
+successful_upsert_tasks = []
+
 
 class HRQBTask(luigi.Task):
     """Base Task class for all HRQB Tasks."""
@@ -26,6 +27,10 @@ class HRQBTask(luigi.Task):
     pipeline = luigi.Parameter()
     stage: Literal["Extract", "Transform", "Load"] = luigi.Parameter()
     table_name = luigi.OptionalStrParameter(default=None)
+
+    @property
+    def name(self) -> str:
+        return self.__class__.__name__
 
     @property
     def path(self) -> str:
@@ -44,9 +49,7 @@ class HRQBTask(luigi.Task):
         likely) contain a single underscore.
         """
         filename = (
-            "__".join(  # noqa: FLY002
-                [self.pipeline, self.stage, self.__class__.__name__]
-            )
+            "__".join([self.pipeline, self.stage, self.name])  # noqa: FLY002
             + self.filename_extension
         )
         return os.path.join(Config().targets_directory(), filename)
@@ -98,9 +101,14 @@ class HRQBTask(luigi.Task):
         access a specific parent Task's output.
         """
         return {
-            task.__class__.__name__: target
+            task.name: target
             for task, target in list(zip(self.deps(), self.input(), strict=True))
         }
+
+
+@HRQBTask.event_handler(luigi.Event.SUCCESS)
+def task_success_handler(task: HRQBTask) -> None:
+    successful_tasks.append(task)
 
 
 class PandasPickleTask(HRQBTask):
@@ -205,6 +213,12 @@ class QuickbaseUpsertTask(HRQBTask):
             table_name=self.table_name,
         )
 
+    @property
+    def parse_upsert_counts(self) -> dict | None:
+        if self.target.exists():
+            return QBClient.parse_upsert_results(self.target.read())
+        return None
+
     def get_records(self) -> list[dict]:
         """Get Records data that will be upserted to Quickbase.
 
@@ -248,39 +262,12 @@ class QuickbaseUpsertTask(HRQBTask):
         )
         results = qbclient.upsert_records(upsert_payload)
 
-        self.parse_and_log_upsert_results(results)
-        self.parse_and_log_upsert_errors(results)
-
         self.target.write(results)
 
-    def parse_and_log_upsert_results(self, api_response: dict) -> None:
-        """Parse Quickbase upsert response and log counts of records modified."""
-        record_counts = QBClient.parse_upsert_results(api_response)
-        if not record_counts:
-            return  # pragma: nocover
-        for key in ["created", "updated", "unchanged"]:
-            record_counts[key] = len(record_counts[key])
-        message = f"Upsert results: {record_counts}"
-        logger.info(message)
 
-    def parse_and_log_upsert_errors(self, api_response: dict) -> None:
-        """Parse Quickbase upsert response and log any errors.
-
-        Errors are returned for each record upserted, for each field with issues.  This is
-        an unnecessary level of grain for logging, so the field error types are counted
-        across all records and logged.  This gives a high level overview of fields that
-        are failing, and how often, where further debugging would involve looking at the
-        response directly in the task output.
-        """
-        if api_errors := api_response.get("metadata", {}).get("lineErrors"):
-            api_error_counts: dict[str, int] = defaultdict(int)
-            for errors in api_errors.values():
-                for error in errors:
-                    api_error_counts[error] += 1
-            message = "Quickbase API call completed but had errors: " + json.dumps(
-                api_error_counts
-            )
-            logger.warning(message)
+@QuickbaseUpsertTask.event_handler(luigi.Event.SUCCESS)
+def upsert_task_success_handler(task: QuickbaseUpsertTask) -> None:
+    successful_upsert_tasks.append(task)
 
 
 class HRQBPipelineTask(luigi.WrapperTask):
@@ -304,8 +291,12 @@ class HRQBPipelineTask(luigi.WrapperTask):
     parent_pipeline_name = luigi.OptionalStrParameter(default=None, significant=False)
 
     @property
+    def name(self) -> str:
+        return self.__class__.__name__
+
+    @property
     def pipeline_name(self) -> str:
-        output = self.__class__.__name__
+        output = self.name
         if self.parent_pipeline_name:
             output = f"{self.parent_pipeline_name}__{output}"
         return output
@@ -322,15 +313,16 @@ class HRQBPipelineTask(luigi.WrapperTask):
         return task_class(**pipeline_parameters or {})
 
     def pipeline_tasks_iter(
-        self, task: luigi.Task | None = None, level: int = 0
+        self,
+        task: HRQBTask | None = None,
+        level: int = 0,
     ) -> Iterator[tuple[int, luigi.Task]]:
         """Yield all Tasks that are part of the dependency chain for this Task.
 
         This method begins with the Pipeline Task itself, then recursively discovers and
         yields parent Tasks as they are required.
         """
-        if task is None:
-            task = self
+        task = task or self
         yield level, task
         for parent_task in task.requires():
             yield from self.pipeline_tasks_iter(task=parent_task, level=level + 1)
@@ -352,7 +344,7 @@ class HRQBPipelineTask(luigi.WrapperTask):
             else task_class_or_name
         )
         for _, task in self.pipeline_tasks_iter():
-            if task.__class__.__name__ == task_class_name:
+            if task.name == task_class_name:
                 return task
         return None
 
@@ -374,3 +366,17 @@ class HRQBPipelineTask(luigi.WrapperTask):
                 target.remove()
                 message = f"Target {target} successfully removed"
                 logger.debug(message)
+
+    def aggregate_upsert_results(self) -> dict | None:
+        """Aggregate upsert results for Load tasks from pipeline run."""
+        if not successful_upsert_tasks:
+            return None
+        results = {"tasks": {}, "qb_upsert_errors": False}
+        for task in successful_upsert_tasks:
+            result = None
+            if task.target.exists():
+                result = QBClient.parse_upsert_results(task.target.read())
+                if result and result.get("errors") is not None:
+                    results["qb_upsert_errors"] = True
+            results["tasks"][task.name] = result  # type: ignore[index]
+        return results

--- a/hrqb/utils/luigi.py
+++ b/hrqb/utils/luigi.py
@@ -1,10 +1,15 @@
 """hrqb.utils.luigi"""
 
+import json
+import logging
+
 import luigi  # type: ignore[import-untyped]
 from luigi.execution_summary import LuigiRunResult  # type: ignore[import-untyped]
 
 from hrqb.base.task import HRQBPipelineTask
 from hrqb.config import Config
+
+logger = logging.getLogger(__name__)
 
 
 def run_task(task: luigi.Task) -> LuigiRunResult:
@@ -17,11 +22,13 @@ def run_task(task: luigi.Task) -> LuigiRunResult:
     )
 
 
-def run_pipeline(pipeline_task: luigi.WrapperTask) -> LuigiRunResult:
+def run_pipeline(pipeline_task: HRQBPipelineTask) -> LuigiRunResult:
     """Function to run a HRQBPipelineTask."""
     if not isinstance(pipeline_task, HRQBPipelineTask):
-        message = (
-            f"{pipeline_task.__class__.__name__} is not a HRQBPipelineTask type task"
-        )
+        message = f"{pipeline_task.name} is not a HRQBPipelineTask type task"
         raise TypeError(message)
-    return run_task(pipeline_task)
+    results = run_task(pipeline_task)
+    if upsert_results := pipeline_task.aggregate_upsert_results():
+        message = f"Upsert results: {json.dumps(upsert_results)}"
+        logger.info(message)
+    return results

--- a/tests/fixtures/tasks/load.py
+++ b/tests/fixtures/tasks/load.py
@@ -1,3 +1,5 @@
+import json
+
 import luigi
 
 from hrqb.base import QuickbaseUpsertTask
@@ -20,9 +22,10 @@ class LoadAnimalsDebug(QuickbaseUpsertTask):
         return [PrepareAnimals(pipeline=self.pipeline)]
 
     def run(self):
-        """Override default method to print data instead of upsert to Quickbase."""
+        """Override default method to print input data and simulate successful upsert."""
         print(self.single_input_dataframe)  # noqa: T201
-        self.target.write({"note": "data printed to console"})
+        with open("tests/fixtures/qb_api_responses/upsert.json") as f:
+            self.target.write(json.load(f))
 
 
 class LoadTaskMultipleRequired(QuickbaseUpsertTask):

--- a/tests/test_qbclient_client.py
+++ b/tests/test_qbclient_client.py
@@ -204,9 +204,10 @@ def test_qbclient_test_connection_response_error(qbclient):
 def test_qbclient_parse_upsert_results_response_success(qbclient, mocked_qb_api_upsert):
     assert qbclient.parse_upsert_results(mocked_qb_api_upsert) == {
         "processed": 3,
-        "created": [11, 12],
-        "updated": [1],
-        "unchanged": [],
+        "created": 2,
+        "updated": 1,
+        "unchanged": 0,
+        "errors": None,
     }
 
 


### PR DESCRIPTION
### Purpose and background context

Formerly, each `QuickbaseUpsertTask` (tasks that actually upsert data to Quickbase) would individually log metrics about modified records.  This made it difficult to quickly get a holistic picture of the run; how many tables had how many updates.  The methods were also logging oriented vs data oriented, which made working with that data in other contexts tricky.

How this addresses that need:
* Utilize luigi [Events and Callbacks](https://luigi.readthedocs.io/en/stable/tasks.html#events-and-callbacks) to pinpoint tasks only from the current run
* Shift parsing up upsert results to `QBClient`
* Add method `HRQBPipelineTask.aggregate_upsert_results()` to aggregate all upsert results, across all Load tasks that fired during the run

By utilizing luigi Events, this also paves the way for better task data cleanup, if we want to only pinpoint tasks that ran during the last run (though not yet implemented).

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
YES: updated logging structure

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/HRQB-20

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes

