### PR TITLE
HRQB 41 - Improve task scoping for runs and data cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ Options:
 ```text
 Usage: -c pipeline [OPTIONS] COMMAND [ARGS]...
 
+  Command group for pipeline actions (e.g. status, run, remove-data).
+
 Options:
   -p, --pipeline TEXT             Pipeline Task class name to be imported from
                                   configured pipeline module, e.g.
@@ -76,12 +78,14 @@ Options:
                                   Comma separated list of luigi Parameters to
                                   pass to HRQBPipelineTask, e.g.
                                   'Param1=foo,Param2=bar'.
-  -t, --task TEXT                 Select a target task for pipeline sub-
-                                  commands (e.g. remove-data, run, etc.)
+  -i, --include TEXT              Comma separated list of tasks to INCLUDE for
+                                  pipeline sub-commands
+  -e, --exclude TEXT              Comma separated list of tasks to EXCLUDE for
+                                  pipeline sub-commands
   -h, --help                      Show this message and exit.
 
 Commands:
-  remove-data  Remove target data from pipeline tasks.
+  remove-data  Remove target data from scoped pipeline tasks.
   run          Run a pipeline.
   status       Get status of a pipeline's tasks.
 ```
@@ -104,10 +108,7 @@ Options:
 ```text
 Usage: -c pipeline remove-data [OPTIONS]
 
-  Remove target data from pipeline tasks.
-
-  If argument --task is passed to parent 'pipeline' command, only this task
-  will have its target data removed.
+  Remove target data from scoped pipeline tasks.
 
 Options:
   -h, --help  Show this message and exit.
@@ -121,11 +122,8 @@ Usage: -c pipeline run [OPTIONS]
 
   Run a pipeline.
 
-  If argument --task is passed to parent 'pipeline' command, only this task,
-  and the tasks it requires, will run.
-
 Options:
-  --cleanup   Remove target data for all tasks in pipeline after run.
+  --cleanup   Remove target data for tasks run during pipeline.
   -h, --help  Show this message and exit.
 ```
 

--- a/hrqb/base/task.py
+++ b/hrqb/base/task.py
@@ -334,8 +334,12 @@ class HRQBPipelineTask(luigi.WrapperTask):
     def verify_include_and_exclude_tasks_exist(self) -> None:
         """Verify that included and excluded tasks exist in the pipeline."""
         filter_tasks = (self.include_tasks or ()) + (self.exclude_tasks or ())
+        all_pipeline_tasks = {
+            task.name: task
+            for _, task in self.pipeline_tasks_iter(use_default_requires=True)
+        }
         for task_name in filter_tasks:
-            if self.get_task(task_name) is None:
+            if task_name not in all_pipeline_tasks:
                 raise TaskNotInPipelineScopeError(task_name)
 
     @staticmethod

--- a/hrqb/base/task.py
+++ b/hrqb/base/task.py
@@ -213,13 +213,6 @@ class QuickbaseUpsertTask(HRQBTask):
             table_name=self.table_name,
         )
 
-    @property
-    def parse_upsert_counts(self) -> dict | None:
-        """Parse results of upsert via QBClient method, if target data exists from run."""
-        if self.target.exists():
-            return QBClient.parse_upsert_results(self.target.read())
-        return None
-
     def get_records(self) -> list[dict]:
         """Get Records data that will be upserted to Quickbase.
 

--- a/hrqb/cli.py
+++ b/hrqb/cli.py
@@ -138,7 +138,7 @@ def pipeline(
             pipeline_parameters=pipeline_parameters,
         )
     except TaskNotInPipelineScopeError as exc:
-        message = f"--include-tasks or --exclude-task are invalid: {exc}, exiting"
+        message = f"CLI options --include or --exclude are invalid: {exc} Exiting."
         raise click.ClickException(message) from exc
 
     ctx.obj["PIPELINE_TASK"] = pipeline_task
@@ -161,6 +161,8 @@ def remove_data(ctx: click.Context) -> None:
     pipeline_task = ctx.obj["PIPELINE_TASK"]
     pipeline_task.remove_pipeline_targets()
     logger.info("Successfully removed target data(s).")
+    logger.info("Updated status after data cleanup:")
+    logger.info(pipeline_task.pipeline_as_ascii())
 
 
 @pipeline.command()
@@ -183,5 +185,3 @@ def run(
 
     if cleanup:
         ctx.invoke(remove_data)
-        logger.info("Updated status after data cleanup:")
-        logger.info(pipeline_task.pipeline_as_ascii())

--- a/hrqb/exceptions.py
+++ b/hrqb/exceptions.py
@@ -3,3 +3,22 @@
 
 class QBFieldNotFoundError(ValueError):
     pass
+
+
+class ExcludedTaskRequiredError(RuntimeError):
+    """Raised when an excluded pipeline task is required but has no target data."""
+
+    def __init__(self, task_name: str) -> None:
+        self.message = (
+            f"Task '{task_name}' was required by pipeline but is explicitly "
+            "excluded and does not have pre-existing target data."
+        )
+        super().__init__(self.message)
+
+
+class TaskNotInPipelineScopeError(ValueError):
+    """Raised when a task is referenced in pipeline but not part of task dependencies."""
+
+    def __init__(self, task_name: str) -> None:
+        self.message = f"Task '{task_name}' not found in pipeline."
+        super().__init__(self.message)

--- a/hrqb/tasks/pipelines.py
+++ b/hrqb/tasks/pipelines.py
@@ -10,7 +10,7 @@ from hrqb.base.task import HRQBPipelineTask
 class FullUpdate(HRQBPipelineTask):
     """Pipeline to perform a full update of all Quickbase tables."""
 
-    def requires(self) -> Iterator[luigi.Task]:  # pragma: no cover
+    def default_requires(self) -> Iterator[luigi.Task]:  # pragma: no cover
         from hrqb.tasks.employee_appointments import LoadEmployeeAppointments
         from hrqb.tasks.employee_leave import LoadEmployeeLeave
         from hrqb.tasks.employee_salary_history import LoadEmployeeSalaryHistory
@@ -48,7 +48,7 @@ class UpdateLibHRData(HRQBPipelineTask):
 
     csv_filepath = luigi.Parameter()
 
-    def requires(self) -> Iterator[luigi.Task]:  # pragma: no cover
+    def default_requires(self) -> Iterator[luigi.Task]:  # pragma: no cover
         from hrqb.tasks.libhr_employee_appointments import LoadLibHREmployeeAppointments
 
         yield LoadLibHREmployeeAppointments(

--- a/hrqb/utils/__init__.py
+++ b/hrqb/utils/__init__.py
@@ -69,6 +69,14 @@ def click_argument_to_dict(
     return dict(pair.split("=") for pair in value.split(","))
 
 
+def click_argument_to_list(
+    _ctx: click.Context, _parameter: click.Parameter, value: str
+) -> list:
+    if value is None:
+        return None
+    return value.split(",")
+
+
 def convert_oracle_bools_to_qb_bools(
     dataframe: pd.DataFrame,
     columns: list[str],

--- a/hrqb/utils/luigi.py
+++ b/hrqb/utils/luigi.py
@@ -1,12 +1,10 @@
 """hrqb.utils.luigi"""
 
-import json
 import logging
 
 import luigi  # type: ignore[import-untyped]
 from luigi.execution_summary import LuigiRunResult  # type: ignore[import-untyped]
 
-from hrqb.base.task import HRQBPipelineTask
 from hrqb.config import Config
 
 logger = logging.getLogger(__name__)
@@ -20,15 +18,3 @@ def run_task(task: luigi.Task) -> LuigiRunResult:
         detailed_summary=True,
         workers=Config().LUIGI_NUM_WORKERS or 1,
     )
-
-
-def run_pipeline(pipeline_task: HRQBPipelineTask) -> LuigiRunResult:
-    """Function to run a HRQBPipelineTask."""
-    if not isinstance(pipeline_task, HRQBPipelineTask):
-        message = f"{pipeline_task.name} is not a HRQBPipelineTask type task"
-        raise TypeError(message)
-    results = run_task(pipeline_task)
-    if upsert_results := pipeline_task.aggregate_upsert_results():
-        message = f"Upsert results: {json.dumps(upsert_results)}"
-        logger.info(message)
-    return results

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,9 @@ ignore = [
     "PLR0915",
     "S301",
     "S320",
-    "S321", 
+    "S321",
+    "TD002",
+    "TD003"
 ]
 
 # allow autofix behavior for specified rules

--- a/tests/fixtures/full_annotated_pipeline.py
+++ b/tests/fixtures/full_annotated_pipeline.py
@@ -84,5 +84,5 @@ class CombineLettersAndNumbers(PandasPickleTask):
 class AlphaNumeric(HRQBPipelineTask):
     """Pipeline Task that's only requirement is yielding required Tasks."""
 
-    def requires(self):
+    def default_requires(self):
         yield CombineLettersAndNumbers(pipeline=self.pipeline_name)

--- a/tests/fixtures/tasks/pipelines.py
+++ b/tests/fixtures/tasks/pipelines.py
@@ -3,15 +3,15 @@ from tests.fixtures.tasks.load import LoadAnimals, LoadAnimalsDebug
 
 
 class Animals(HRQBPipelineTask):
-    def requires(self):
+    def default_requires(self):
         yield LoadAnimals(pipeline=self.pipeline_name)
 
 
 class AnimalsDebug(HRQBPipelineTask):
-    def requires(self):
+    def default_requires(self):
         yield LoadAnimalsDebug(pipeline=self.pipeline_name)
 
 
 class Creatures(HRQBPipelineTask):
-    def requires(self):
+    def default_requires(self):
         yield Animals(parent_pipeline_name=self.pipeline_name)

--- a/tests/test_base_task.py
+++ b/tests/test_base_task.py
@@ -163,31 +163,6 @@ def test_quickbase_task_run_upsert_and_json_receipt_output_target_success(
     assert task_load_animals.target.read() == mocked_qb_upsert_receipt
 
 
-def test_quickbase_task_run_upsert_and_json_receipt_output_target_api_errors_logged(
-    caplog, task_transform_animals_target, task_load_animals
-):
-    """Mocks upsert to Quickbase, asserting mocked response is written as Target data"""
-    mocked_qb_upsert_receipt = {
-        "data": [],
-        "metadata": {
-            "createdRecordIds": [11, 12],
-            "lineErrors": {"2": ['Incompatible value for field with ID "6".']},
-            "totalNumberOfRecordsProcessed": 3,
-            "unchangedRecordIds": [],
-            "updatedRecordIds": [],
-        },
-    }
-    with mock.patch("hrqb.base.task.QBClient", autospec=True) as mock_qbclient_class:
-        mock_qbclient = mock_qbclient_class()
-        mock_qbclient.get_table_id.return_value = "abcdef123"
-        mock_qbclient.prepare_upsert_payload.return_value = {}
-        mock_qbclient.upsert_records.return_value = mocked_qb_upsert_receipt
-
-        task_load_animals.run()
-
-    assert "errors" in task_load_animals.parse_upsert_counts
-
-
 def test_base_pipeline_name(task_pipeline_animals):
     assert task_pipeline_animals.pipeline_name == "Animals"
 
@@ -319,10 +294,7 @@ def test_base_pipeline_task_aggregate_upsert_results_failed_load_returns_none_va
         mocked_run.side_effect = Exception("UPSERT FAILED!")
         run_pipeline(task_pipeline_animals_debug)
 
-    assert task_pipeline_animals_debug.aggregate_upsert_results() == {
-        "qb_upsert_errors": False,
-        "tasks": {"LoadAnimalsDebug": None},
-    }
+    assert task_pipeline_animals_debug.aggregate_upsert_results() == None
 
 
 def test_base_pipeline_task_aggregate_upsert_results_upsert_with_errors_noted(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -105,8 +105,8 @@ def test_cli_pipeline_remove_data_task_not_found(
     result = runner.invoke(cli.main, args)
     assert result.exit_code == ERROR_RESULT_CODE
     assert (
-        "--include-tasks or --exclude-task are invalid: Task 'BadTask' not found in "
-        "pipeline" in result.output
+        "CLI options --include or --exclude are invalid: Task 'BadTask' not found in "
+        "pipeline. Exiting." in result.output
     )
 
 
@@ -211,8 +211,8 @@ def test_cli_pipeline_run_start_task_not_found_error(caplog, runner):
     result = runner.invoke(cli.main, args)
     assert result.exit_code == ERROR_RESULT_CODE
     assert (
-        "--include-tasks or --exclude-task are invalid: Task 'BadTask' not found in "
-        "pipeline" in result.output
+        "CLI options --include or --exclude are invalid: Task 'BadTask' not found in "
+        "pipeline. Exiting." in result.output
     )
 
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,16 @@
+from hrqb.exceptions import ExcludedTaskRequiredError, TaskNotInPipelineScopeError
+
+TASK_NAME = "TaskFoo"
+
+
+def test_excluded_task_required_exception_message():
+    exc = ExcludedTaskRequiredError("TaskFoo")
+    assert str(exc) == (
+        f"Task '{TASK_NAME}' was required by pipeline but is explicitly "
+        "excluded and does not have pre-existing target data."
+    )
+
+
+def test_task_not_in_pipeline_scope_exception_message():
+    exc = TaskNotInPipelineScopeError("TaskFoo")
+    assert str(exc) == f"Task '{TASK_NAME}' not found in pipeline."

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -1,7 +1,5 @@
 import luigi
-import pytest
 
-from hrqb.utils.luigi import run_pipeline
 from tests.fixtures.full_annotated_pipeline import (
     AlphaNumeric,
     CombineLettersAndNumbers,
@@ -12,7 +10,9 @@ from tests.fixtures.tasks.pipelines import AnimalsDebug
 from tests.fixtures.tasks.transform import PrepareAnimals
 
 
-def test_pipeline_pipeline_tasks_iter_gives_all_parent_tasks(task_pipeline_animals_debug):
+def test_pipeline_pipeline_tasks_iter_gives_all_required_tasks(
+    task_pipeline_animals_debug,
+):
     pipeline_tasks = [
         task for _level, task in task_pipeline_animals_debug.pipeline_tasks_iter()
     ]
@@ -23,7 +23,7 @@ def test_pipeline_pipeline_tasks_iter_gives_all_parent_tasks(task_pipeline_anima
     assert pipeline_tasks[4].__class__ == ExtractAnimalNames  # Extract Task #2
 
 
-def test_pipeline_complete_when_all_parent_tasks_complete(
+def test_pipeline_complete_when_all_required_tasks_complete(
     task_extract_animal_names,
     task_extract_animal_colors,
     task_transform_animals,
@@ -51,7 +51,7 @@ def test_full_annotated_simple_pipeline():
     # we can run the pipeline directly using luigi to demonstrate the Task inputs/outputs
     # and dependencies are automatically handled.  run_pipeline(...) is a custom wrapper
     # function that runs luigi.build(...), and is what's called by CLI commands.
-    results = run_pipeline(AlphaNumeric())
+    results = AlphaNumeric().run_pipeline()
 
     # assert successful results
     assert results.status == luigi.LuigiStatusCode.SUCCESS
@@ -66,13 +66,3 @@ def test_full_annotated_simple_pipeline():
         "number": {0: 0, 1: 10, 2: 20, 3: 30, 4: 40},
         "letter": {0: "a", 1: "b", 2: "c", 3: "d", 4: "e"},
     }
-
-
-def test_run_pipeline_with_non_hrqbpipelinetask_type_raise_error(
-    task_extract_animal_names,
-):
-    with pytest.raises(
-        TypeError,
-        match="ExtractAnimalNames is not a HRQBPipelineTask type task",
-    ):
-        run_pipeline(task_extract_animal_names)

--- a/tests/test_qbclient_client.py
+++ b/tests/test_qbclient_client.py
@@ -211,6 +211,26 @@ def test_qbclient_parse_upsert_results_response_success(qbclient, mocked_qb_api_
     }
 
 
+def test_qbclient_parse_upsert_results_response_captures_line_errors(qbclient):
+    mocked_qb_upsert_receipt = {
+        "data": [],
+        "metadata": {
+            "createdRecordIds": [11, 12],
+            "lineErrors": {"2": ['Incompatible value for field with ID "6".']},
+            "totalNumberOfRecordsProcessed": 3,
+            "unchangedRecordIds": [],
+            "updatedRecordIds": [],
+        },
+    }
+    assert qbclient.parse_upsert_results(mocked_qb_upsert_receipt) == {
+        "processed": 3,
+        "created": 2,
+        "errors": {'Incompatible value for field with ID "6".': 1},
+        "updated": 0,
+        "unchanged": 0,
+    }
+
+
 def test_qbclient_parse_upsert_results_response_error_return_none(qbclient):
     assert qbclient.parse_upsert_results({"msg": "bad API response"}) is None
 


### PR DESCRIPTION
### Purpose and background context

This PR reworks the CLI `--task` flag into two new ones `--include` and `--exclude`.  Using a combination of these, it's now possible to:
  - load a pipeline, but begin from any task in the pipeline dependencies
  - exclude tasks from running or having their data cleared between runs

These changes dovetail with some improvements to how pipelines run, including moving the `run_pipeline()` function to a method on `HRQBPipelineTask`, where it should only ever run anyhow.

Taken altogether, the output of HRQBClient will remain identical.  All changes are for local development convenience.  When working on a particular task or family of tasks, it is much easier to isolate them for development.

Some areas of interest:
  - Instead of a default `requires()` method, `HRQBPipelineTasks` now expect a [`default_requires()` method](https://github.com/MITLibraries/hrqb-client/pull/106/files#diff-d86e429c2a92dbd803698c92d15054d84cd0886541acd33a95f26ec5e48d39e6R309-R315) ([example](https://github.com/MITLibraries/hrqb-client/pull/106/files#diff-76ca543a795fd46ff3d9bf2f543e0a49352c70c84c8c3d4f8f06c93d7514b349R13-R24))
    - this sets the _default_ root tasks for a pipeline, but can be overridden by `--include-tasks` CLI flag, by [new shared `requires()` method and helpers](https://github.com/MITLibraries/hrqb-client/pull/106/files#diff-d86e429c2a92dbd803698c92d15054d84cd0886541acd33a95f26ec5e48d39e6R317-R332)
  - `luigi.utils.run_pipeline()` moved to [method on `HRQBPipelineTasks`](https://github.com/MITLibraries/hrqb-client/pull/106/files#diff-d86e429c2a92dbd803698c92d15054d84cd0886541acd33a95f26ec5e48d39e6R435-R456) and includes setup + cleanup logic
    - setup: determine if include/exclude tasks actually exist, clear out memory of previous runs, raise exceptions if tasks are required to run but have been explicitly excluded
    - cleanup: remove data from run if flagged to do so, skipping excluding tasks

### How can a reviewer manually see the effects of these changes?

Some manual testing is possible with these changes, as we can use test fixtures.

The following should show all tasks as`INCOMPLETE`:
```shell
pipenv run hrqb --verbose pipeline \
--pipeline-module=tests.fixtures.full_annotated_pipeline \
--pipeline=AlphaNumeric \
status
```

Here is the status and tasks of this pipeline:
```
├── INCOMPLETE: AlphaNumeric()
   ├── INCOMPLETE: CombineLettersAndNumbers(table_name=, pipeline=AlphaNumeric, stage=Transform)
      ├── INCOMPLETE: MultiplyNumbers(table_name=, pipeline=AlphaNumeric, stage=Transform)
         ├── INCOMPLETE: GenerateNumbers(table_name=, pipeline=AlphaNumeric, stage=Extract)
      ├── INCOMPLETE: GenerateLetters(table_name=, pipeline=AlphaNumeric, stage=Extract)
```

If not, run this command to fully clear data:
```shell
pipenv run hrqb --verbose pipeline \
--pipeline-module=tests.fixtures.full_annotated_pipeline \
--pipeline=AlphaNumeric \
remove-data
```

Now, we can fun the full pipeline:
```shell
pipenv run hrqb --verbose pipeline \
--pipeline-module=tests.fixtures.full_annotated_pipeline \
--pipeline=AlphaNumeric \
run
```

Imagine now that we need to work on the `MultiplyNumbers` task.  By using `--include-tasks` and `--exclude-tasks` we can pinpoint this task, remove it's data each time, but keep data from other required tasks.

The following shows that `--include` limits scope to `MultiplyNumbers` and its required tasks:
```shell
pipenv run hrqb --verbose pipeline \
--pipeline-module=tests.fixtures.full_annotated_pipeline \
--pipeline=AlphaNumeric \
--include=MultiplyNumbers \
--exclude=GenerateNumbers,GenerateLetters \
status
```

Given the includes/excludes, we can remove all data while keeping data from desired tasks:
```shell
pipenv run hrqb --verbose pipeline \
--pipeline-module=tests.fixtures.full_annotated_pipeline \
--pipeline=AlphaNumeric \
--include=MultiplyNumbers \
--exclude=GenerateNumbers,GenerateLetters \
remove-data
```

In our development loop for making and testing changes to `MultiplyNumbers`, we can run this command repeatedly knowing that it will only run and cleanup data we expect:
```shell
pipenv run hrqb --verbose pipeline \
--pipeline-module=tests.fixtures.full_annotated_pipeline \
--pipeline=AlphaNumeric \
--include=MultiplyNumbers \
--exclude=GenerateNumbers,GenerateLetters \
run --cleanup
```

The output from this indicates as much, showing fully complete and successful, then data removed:
```
2024-07-16 09:52:26,824 INFO hrqb.cli.run() line 183: Pipeline run result: SUCCESS
2024-07-16 09:52:26,825 INFO hrqb.cli.run() line 184: 
├── COMPLETE: AlphaNumeric()
   ├── COMPLETE: MultiplyNumbers(table_name=, pipeline=AlphaNumeric, stage=Transform)
      ├── COMPLETE: GenerateNumbers(table_name=, pipeline=AlphaNumeric, stage=Extract)
2024-07-16 09:52:26,826 INFO hrqb.cli.remove_data() line 163: Successfully removed target data(s).
2024-07-16 09:52:26,826 INFO hrqb.cli.remove_data() line 164: Updated status after data cleanup:
2024-07-16 09:52:26,827 INFO hrqb.cli.remove_data() line 165: 
├── INCOMPLETE: AlphaNumeric()
   ├── INCOMPLETE: MultiplyNumbers(table_name=, pipeline=AlphaNumeric, stage=Transform)
      ├── COMPLETE: GenerateNumbers(table_name=, pipeline=AlphaNumeric, stage=Extract)
```

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/HRQB-41

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes

