### PR TITLE
HRQB 27 - establish integrity checks pattern and Employees check

### DIFF
--- a/hrqb/base/task.py
+++ b/hrqb/base/task.py
@@ -223,6 +223,17 @@ class QuickbaseUpsertTask(HRQBTask):
             records_df = self.named_inputs[self.input_task_to_load].read()
         else:
             records_df = self.single_input_dataframe
+
+        if (
+            self.merge_field
+            and len(records_df[records_df.duplicated(self.merge_field)]) > 0
+        ):
+            message = (
+                f"Merge field '{self.merge_field}' found to have duplicate "
+                f"values for task '{self.name}'"
+            )
+            raise ValueError(message)
+
         records_df = self._normalize_records_for_upsert(records_df)
         return records_df.to_dict(orient="records")
 

--- a/hrqb/base/task.py
+++ b/hrqb/base/task.py
@@ -305,7 +305,6 @@ class QuickbaseUpsertTask(HRQBTask):
         records = self.get_records()
         results = self.upsert_records(records)
         self.run_integrity_checks(results)
-
         self.target.write(results)
 
 

--- a/hrqb/base/task.py
+++ b/hrqb/base/task.py
@@ -9,6 +9,7 @@ from typing import Literal
 import luigi  # type: ignore[import-untyped]
 import numpy as np
 import pandas as pd
+import sentry_sdk
 
 from hrqb.base import PandasPickleTarget, QuickbaseTableTarget
 from hrqb.config import Config
@@ -128,7 +129,9 @@ class HRQBTask(luigi.Task):
                     check_func(*args, **kwargs)
                 except Exception as exc:
                     message = f"Task '{self.name}' failed integrity check: '{exc}'"
-                    raise IntegrityCheckError(message) from exc
+                    integrity_exception = IntegrityCheckError(message)
+                    sentry_sdk.capture_exception(integrity_exception)
+                    raise integrity_exception from exc
 
 
 @HRQBTask.event_handler(luigi.Event.SUCCESS)

--- a/hrqb/config.py
+++ b/hrqb/config.py
@@ -102,9 +102,9 @@ def _remove_sensitive_scope_variables(event: Event) -> Event:
     object separately.
     """
     new_event = copy.deepcopy(event)
-    if "exception" in new_event:
-        for exc_type in new_event["exception"]["values"]:
-            for stacktrace in exc_type.get("stacktrace", {}).get("frames", []):
-                for item in ["vars", "pre_context", "post_context"]:
-                    stacktrace.pop(item, None)
+    for captured_exception in new_event.get("exception", {}).get("values", []):
+        for frame in captured_exception.get("stacktrace", {}).get("frames", []):
+            for item in ["vars", "pre_context", "post_context"]:
+                if item in frame:
+                    frame.pop(item, None)
     return new_event

--- a/hrqb/exceptions.py
+++ b/hrqb/exceptions.py
@@ -3,3 +3,7 @@
 
 class QBFieldNotFoundError(ValueError):
     pass
+
+
+class IntegrityCheckError(Exception):
+    pass

--- a/hrqb/tasks/employees.py
+++ b/hrqb/tasks/employees.py
@@ -4,6 +4,7 @@ import luigi  # type: ignore[import-untyped]
 import pandas as pd
 
 from hrqb.base.task import (
+    HRQBTask,
     PandasPickleTask,
     QuickbaseUpsertTask,
     SQLQueryExtractTask,
@@ -78,6 +79,13 @@ class TransformEmployees(PandasPickleTask):
             "termination_reason": "Termination Type",
         }
         return employees_df[fields.keys()].rename(columns=fields)
+
+    @HRQBTask.integrity_check
+    def check_unique_mit_ids(self, output_df: pd.DataFrame) -> None:
+        duplicate_mit_ids = len(output_df[output_df.duplicated("MIT ID", keep=False)])
+        if duplicate_mit_ids > 0:
+            message = f"Found {duplicate_mit_ids} duplicate 'MIT ID' column values"
+            raise ValueError(message)
 
 
 class LoadEmployees(QuickbaseUpsertTask):

--- a/tests/tasks/test_employees.py
+++ b/tests/tasks/test_employees.py
@@ -1,3 +1,7 @@
+import pandas as pd
+import pytest
+
+
 def test_extract_dw_employees_load_sql_query(task_extract_dw_employees):
     assert task_extract_dw_employees.sql_file == "hrqb/tasks/sql/employees.sql"
     assert task_extract_dw_employees.sql_query is not None
@@ -22,3 +26,12 @@ def test_transform_employees_normalize_state_names(
 
 def test_task_load_employee_appointments_explicit_properties(task_load_employees):
     assert task_load_employees.merge_field == "MIT ID"
+
+
+def test_transform_employees_integrity_check_duplicate_mit_ids(task_transform_employees):
+    test_df = pd.DataFrame(
+        ["55555", "55555", "12345", "67890"],
+        columns=["MIT ID"],
+    )
+    with pytest.raises(ValueError, match="Found 2 duplicate 'MIT ID' column values"):
+        task_transform_employees.check_unique_mit_ids(test_df)


### PR DESCRIPTION
### Purpose and background context

This PR introduces integrity checks to the HRQBClient for testing data either prepared by tasks or upserted into Quickbase.  These are "runtime" tests in the sense that they assert data quality and integrity during an actual pipeline run. 

This is opposed to unit tests which are helpful for confirming the schema of tasks inputs and outputs, or business logic in the tasks.

These integrity checks are designed to catch data quality issues that may crop up from data changing in the data warehouse or Quickbase, which unit tests could not account for.

If an integrity check fails, the task is considered unsuccessful and details about the failure are reported to Sentry for investigation.

Integrity checks are applied to tasks in the following way:
  1. `HRQBTask` has [new method `integrity_check`](https://github.com/MITLibraries/hrqb-client/pull/113/files#diff-d86e429c2a92dbd803698c92d15054d84cd0886541acd33a95f26ec5e48d39e6R110-R116) designed to be used as a decorator
  2. a method in a task is decorated with `HRQBTask.integrity_check` ([example](https://github.com/MITLibraries/hrqb-client/pull/113/files#diff-244333a113ecfa98fd1adc7608d4d8ccd9dfa02c6137250a151530ad408870bcR83-R88))
  3. this [registers the method](https://github.com/MITLibraries/hrqb-client/pull/113/files#diff-d86e429c2a92dbd803698c92d15054d84cd0886541acd33a95f26ec5e48d39e6R113-R115) as an integrity check at the class level
  4. `HRQBTask` contains a [new method `run_integrity_checks()`](https://github.com/MITLibraries/hrqb-client/pull/113/files#diff-d86e429c2a92dbd803698c92d15054d84cd0886541acd33a95f26ec5e48d39e6R118-R134)
  5. both `PandasPickleTask` and `QuickbaseUpsertTask` run `self.run_integrity_checks()` during their `run()` method, passing either the dataframe it would output (`PandasPickleTask` [example](https://github.com/MITLibraries/hrqb-client/pull/113/files#diff-d86e429c2a92dbd803698c92d15054d84cd0886541acd33a95f26ec5e48d39e6R169)) or the results of the upsert (`QuickbaseUpsertTask` [example](https://github.com/MITLibraries/hrqb-client/pull/113/files#diff-d86e429c2a92dbd803698c92d15054d84cd0886541acd33a95f26ec5e48d39e6R307)) for checking

This PR is largely to establish the pattern of these checks, but `Employees` does get the first real check asserting that duplicate `MIT ID`'s would not get upserted to the Quickbase `Employees` table.

### How can a reviewer manually see the effects of these changes?

The new unit tests and fixtures do a decent job of outlining how they function.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
YES: tasks may now fail, and report to Sentry, if integrity checks fail.

### What are the relevant tickets?
- Include links to Jira Software and/or Jira Service Management tickets here.

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes

