### PR TITLE
HRQB 44 - Drop null values from salary change types

### DIFF
--- a/hrqb/tasks/salary_change_types.py
+++ b/hrqb/tasks/salary_change_types.py
@@ -17,11 +17,12 @@ class TransformSalaryChangeTypes(PandasPickleTask):
 
     def get_dataframe(self) -> pd.DataFrame:
         fields = {"hr_personnel_action": "Salary Change Type"}
-        return (
+        salary_types_df = (
             self.single_input_dataframe[fields.keys()]
             .drop_duplicates()
             .rename(columns=fields)
         )
+        return salary_types_df[~salary_types_df["Salary Change Type"].isna()]
 
 
 class LoadSalaryChangeTypes(QuickbaseUpsertTask):


### PR DESCRIPTION
### Purpose and background context
This PR drops `None` values from the unique list of salary change types.  With these removed, we should not see errors during Quickbase upsert for an invalid value.

Example of this error showing up Cloudwatch logs for upsert results aggregation:

```json
"LoadSalaryChangeTypes": {
            "processed": 26,
            "created": 0,
            "updated": 0,
            "unchanged": 25,
            "errors": {
                "Missing value for required field with ID \"6\".": 1   <------------
            }
        }
```

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
YES: no more errors for `LoadSalaryChangeTypes`

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/HRQB-44

### Developer
- [ ] All new ENV is documented in README
- [ ] All new ENV has been added to staging and production environments
- [ ] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes

