### PR TITLE
HRQB 46 - Send sentry message on upsert errors

### DIFF
--- a/hrqb/utils/luigi.py
+++ b/hrqb/utils/luigi.py
@@ -4,6 +4,7 @@ import json
 import logging
 
 import luigi  # type: ignore[import-untyped]
+import sentry_sdk
 from luigi.execution_summary import LuigiRunResult  # type: ignore[import-untyped]
 
 from hrqb.base.task import HRQBPipelineTask
@@ -27,8 +28,23 @@ def run_pipeline(pipeline_task: HRQBPipelineTask) -> LuigiRunResult:
     if not isinstance(pipeline_task, HRQBPipelineTask):
         message = f"{pipeline_task.name} is not a HRQBPipelineTask type task"
         raise TypeError(message)
+
     results = run_task(pipeline_task)
+
     if upsert_results := pipeline_task.aggregate_upsert_results():
         message = f"Upsert results: {json.dumps(upsert_results)}"
         logger.info(message)
+
+        if upsert_results.get("qb_upsert_errors"):
+            tasks_with_errors = [
+                task_name
+                for task_name, task_results in upsert_results.get("tasks", {}).items()
+                if task_results["errors"] is not None
+            ]
+            sentry_sdk.capture_message(
+                f"Quickbase upsert error(s) detected for tasks: {tasks_with_errors}. "
+                "Please see logs for information on specific errors encountered.",
+                level="warning",
+            )
+
     return results

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -93,7 +93,10 @@ def test_run_pipeline_send_sentry_message_on_upsert_error(mocker):
         AlphaNumeric, "aggregate_upsert_results"
     ) as mocked_agg_results:
         mocked_agg_results.return_value = {
-            "tasks": {"FinickyTask": {"errors": ["Error1", "Error2"]}},
+            "tasks": {
+                "FinickyTask": {"errors": ["Error1", "Error2"]},
+                "SolidTask": {"errors": None},
+            },
             "qb_upsert_errors": True,
         }
         run_pipeline(AlphaNumeric())


### PR DESCRIPTION
### Purpose and background context

When performing upserts to Quickbase, even if some records have errors, the HTTP response will be 200.  It is required to parse the response and see what specific records had errors.  We capture this grain in a method to aggregate upsert results across all tasks, but we only logged it.

Now that all upsert errors have been resolved as a baseline, anything new indicates new data or an edge case we have not encountered.  As such, it is a good time to introduce more warning when this happens.

How this addresses that need:
* Manually send a Sentry message when upsert errors detected

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
YES: Sentry messages sent

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/HRQB-46

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes

