### PR TITLE
HRQB 49 - Include historical LibHR data

### DIFF
--- a/hrqb/tasks/employee_appointments.py
+++ b/hrqb/tasks/employee_appointments.py
@@ -57,6 +57,9 @@ class TransformEmployeeAppointments(PandasPickleTask):
         libhr_df = self.named_inputs["ExtractQBLibHREmployeeAppointments"].read()
         depts_df = self.named_inputs["ExtractQBDepartments"].read()
 
+        # filter libhr data to active appointments, with position IDs
+        libhr_df = libhr_df[(libhr_df["Active"]) & ~(libhr_df["Position ID"].isna())]
+
         # normalize position id to string and pad zeros
         libhr_df["Position ID"] = libhr_df["Position ID"].apply(
             lambda x: str(int(x)).zfill(8)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -653,6 +653,7 @@ def task_extract_qb_libhr_complete(all_tasks_pipeline_name):
                     "Position ID": 987654321,
                     "Cost Object": 7777777,
                     "Related Department ID": 42.0,
+                    "Active": True,
                 }
             ]
         )

--- a/tests/fixtures/libhr_static_data.csv
+++ b/tests/fixtures/libhr_static_data.csv
@@ -1,4 +1,4 @@
 MIT ID,HC ID,Full Name,Position,Position ID,Employee Type,Supervisor ID,Supervisor Name,Cost Object,Department,Active
 123456789,L-001,"Doe, John",Science Librarian,888888888,Admin Staff,444444444,"Smith, Fancy",555555555,DDC,True
 987654321,L-100,"Doe, Jane",Data Engineer,999999999,Admin Staff,444444444,"Smith, Fancy",555555555,ITS,True
-987654321,L-101,"Doe, Jane",DevOps Engineer,999999991,Admin Staff,444444444,"Smith, Fancy",555555555,BAD_ACRO,True
+987654321,L-101x,"Doe, Jane",DevOps Engineer,999999991,Admin Staff,444444444,"Smith, Fancy",555555555,BAD_ACRO,False

--- a/tests/fixtures/libhr_static_data.csv
+++ b/tests/fixtures/libhr_static_data.csv
@@ -1,4 +1,4 @@
-MIT ID,HC ID,Full Name,Position,Position ID,Employee Type,Supervisor ID,Supervisor Name,Cost Object,Department
-123456789,L-001,"Doe, John",Science Librarian,888888888,Admin Staff,444444444,"Smith, Fancy",555555555,DDC
-987654321,L-100,"Doe, Jane",Data Engineer,999999999,Admin Staff,444444444,"Smith, Fancy",555555555,ITS
-987654321,L-100,"Doe, Jane",DevOps Engineer,999999991,Admin Staff,444444444,"Smith, Fancy",555555555,BAD_ACRO
+MIT ID,HC ID,Full Name,Position,Position ID,Employee Type,Supervisor ID,Supervisor Name,Cost Object,Department,Active
+123456789,L-001,"Doe, John",Science Librarian,888888888,Admin Staff,444444444,"Smith, Fancy",555555555,DDC,True
+987654321,L-100,"Doe, Jane",Data Engineer,999999999,Admin Staff,444444444,"Smith, Fancy",555555555,ITS,True
+987654321,L-101,"Doe, Jane",DevOps Engineer,999999991,Admin Staff,444444444,"Smith, Fancy",555555555,BAD_ACRO,True

--- a/tests/tasks/test_libhr_employee_appointments.py
+++ b/tests/tasks/test_libhr_employee_appointments.py
@@ -1,6 +1,5 @@
 # ruff: noqa: PD901, PLR2004
 
-import numpy as np
 import pandas as pd
 
 
@@ -18,39 +17,23 @@ def test_transform_libhr_employee_appointments_merge_departments(
     task_transform_libhr_employee_appointments,
 ):
     new_df = task_transform_libhr_employee_appointments.get_dataframe()
-    assert new_df.equals(
-        pd.DataFrame(
-            [
-                {
-                    "Related Employee MIT ID": 123456789,
-                    "Related Supervisor MIT ID": 444444444,
-                    "Cost Object": 555555555,
-                    "HC ID": "L-001",
-                    "Position ID": 888888888,
-                    "Related Department ID": 35.0,
-                },
-                {
-                    "Related Employee MIT ID": 987654321,
-                    "Related Supervisor MIT ID": 444444444,
-                    "Cost Object": 555555555,
-                    "HC ID": "L-100",
-                    "Position ID": 999999999,
-                    "Related Department ID": 40.0,
-                },
-                {
-                    "Related Employee MIT ID": 987654321,
-                    "Related Supervisor MIT ID": 444444444,
-                    "Cost Object": 555555555,
-                    "HC ID": "L-100",
-                    "Position ID": 999999991,
-                    "Related Department ID": np.nan,
-                },
-            ]
-        )
-    )
+    assert new_df.iloc[0]["Related Department ID"] == 35.0
+    assert new_df.iloc[1]["Related Department ID"] == 40.0
+    assert pd.isna(new_df.iloc[2]["Related Department ID"])  # no match in merge, so NULL
 
 
 def test_load_libhr_employee_appointments_merge_field_set(
     task_load_libhr_employee_appointments,
 ):
-    assert task_load_libhr_employee_appointments.merge_field == "Position ID"
+    assert task_load_libhr_employee_appointments.merge_field == "Key"
+
+
+def test_transform_libhr_employee_appointments_merge_field_key_values(
+    task_transform_libhr_employee_appointments,
+):
+    new_df = task_transform_libhr_employee_appointments.get_dataframe()
+    assert list(new_df["Key"]) == [
+        "81cf06bfd65aa1f7019750c57a79be99",
+        "6e07102ee39ec1f22c63231d090bd4dd",
+        "744aefdd46c40523d60cf69490d81655",
+    ]

--- a/tests/tasks/test_libhr_employee_appointments.py
+++ b/tests/tasks/test_libhr_employee_appointments.py
@@ -35,5 +35,5 @@ def test_transform_libhr_employee_appointments_merge_field_key_values(
     assert list(new_df["Key"]) == [
         "81cf06bfd65aa1f7019750c57a79be99",
         "6e07102ee39ec1f22c63231d090bd4dd",
-        "744aefdd46c40523d60cf69490d81655",
+        "af08a24eeb35fae63fa76e755537b949",
     ]


### PR DESCRIPTION
### Purpose and background context

This PR aligns the HRQBClient with some changes to the Quickbase table `LibHR Employee Appointments`.  

HR wants to include "historical" data in this table, i.e. rows that show a "Headcount ID" for previous roles.  This allows HR to generate reports that show open positions based on Headcount ID `L-XXX` identifiers used internally by HR.

Previously, the `LibHR Employee Appointments` table only had "active" data, so we could join on all rows to augment the `Employee Appointments` rows.  But now that there is "historical" data, we must filter to only a) rows where `Active = Yes` and b) where the `Position ID` is not null (the field actually used for merging).

The changes can be summarized as:
- the `LibHR Employee Appointments` Quickbase table has two new columns
  - `Active`: boolean (in Quickbase, "Yes" or "No") to indicate if an active employee appointment
  - `Key`: a text field that is an MD5 hash of `MIT ID` + `HC ID` to support merge updates in Quickbase
- Updates to task `TransformEmployeeAppointments` to filter out inactive LibHR data rows

### How can a reviewer manually see the effects of these changes?

Still difficult to test locally given permissions.  But [a recent Sentry error](https://mit-libraries.sentry.io/issues/5868040753/?alert_rule_id=15226197&alert_timestamp=1726657382924&alert_type=email&environment=prod&notification_uuid=a755f72e-c37b-4dfb-9d1e-c7196e7ccc1e&project=4507340421726208&referrer=alert_email) was timely as it shows how the `TransformEmployeeAppointments` task failed given the updates to the Quickbase table.

A full run locally was successful, indicating that this Sentry error is resolved by the included changes.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/HRQB-49

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes

