### PR TITLE
HRQB 51 - New table Employee Leave Balances

### DIFF
--- a/hrqb/tasks/employee_leave_balances.py
+++ b/hrqb/tasks/employee_leave_balances.py
@@ -1,0 +1,83 @@
+"""hrqb.tasks.employee_leave_balances"""
+
+import luigi  # type: ignore[import-untyped]
+import pandas as pd
+
+from hrqb.base.task import (
+    PandasPickleTask,
+    QuickbaseUpsertTask,
+    SQLQueryExtractTask,
+)
+from hrqb.utils import (
+    md5_hash_from_values,
+    normalize_dataframe_dates,
+)
+
+
+class ExtractDWEmployeeLeaveBalances(SQLQueryExtractTask):
+    """Query Data Warehouse for employee leave balance data."""
+
+    stage = luigi.Parameter("Extract")
+
+    @property
+    def sql_file(self) -> str:
+        return "hrqb/tasks/sql/employee_leave_balances.sql"
+
+
+class TransformEmployeeLeaveBalances(PandasPickleTask):
+
+    stage = luigi.Parameter("Transform")
+
+    def requires(self) -> list[luigi.Task]:
+        return [ExtractDWEmployeeLeaveBalances(pipeline=self.pipeline)]
+
+    def get_dataframe(self) -> pd.DataFrame:
+        dw_leave_balances_df = self.single_input_dataframe
+
+        dw_leave_balances_df = normalize_dataframe_dates(
+            dw_leave_balances_df,
+            ["absence_balance_begin_date", "absence_balance_end_date"],
+        )
+
+        # mint a unique, deterministic value for the merge "Key" field
+        dw_leave_balances_df["key"] = dw_leave_balances_df.apply(
+            lambda row: md5_hash_from_values(
+                [
+                    row.mit_id,
+                    row.balance_type,
+                ]
+            ),
+            axis=1,
+        )
+
+        fields = {
+            "key": "Key",
+            "mit_id": "MIT ID",
+            "balance_type": "Balance Type",
+            "beginning_balance_hours": "Beginning Balance Hours",
+            "deducted_hours": "Deducted Hours",
+            "ending_balance_hours": "Ending Balance Hours",
+            "beginning_balance_days": "Beginning Balance Days",
+            "deducted_days": "Deducted Days",
+            "ending_balance_days": "Ending Balance Days",
+            "absence_balance_begin_date": "Absence Balance Begin Date",
+            "absence_balance_end_date": "Absence Balance End Date",
+        }
+        return dw_leave_balances_df[fields.keys()].rename(columns=fields)
+
+
+class LoadEmployeeLeaveBalances(QuickbaseUpsertTask):
+
+    stage = luigi.Parameter("Load")
+    table_name = "Employee Leave Balances"
+
+    def requires(self) -> list[luigi.Task]:  # pragma: nocover
+        return [TransformEmployeeLeaveBalances(pipeline=self.pipeline)]
+
+    @property
+    def merge_field(self) -> str | None:
+        return "Key"
+
+    @property
+    def input_task_to_load(self) -> str:
+        return "TransformEmployeeLeaveBalances"

--- a/hrqb/tasks/pipelines.py
+++ b/hrqb/tasks/pipelines.py
@@ -13,6 +13,7 @@ class FullUpdate(HRQBPipelineTask):
     def requires(self) -> Iterator[luigi.Task]:  # pragma: no cover
         from hrqb.tasks.employee_appointments import LoadEmployeeAppointments
         from hrqb.tasks.employee_leave import LoadEmployeeLeave
+        from hrqb.tasks.employee_leave_balances import LoadEmployeeLeaveBalances
         from hrqb.tasks.employee_salary_history import LoadEmployeeSalaryHistory
         from hrqb.tasks.employees import LoadEmployees
         from hrqb.tasks.performance_reviews import LoadPerformanceReviews
@@ -22,6 +23,7 @@ class FullUpdate(HRQBPipelineTask):
         yield LoadEmployeeSalaryHistory(pipeline=self.pipeline_name)
         yield LoadEmployeeLeave(pipeline=self.pipeline_name)
         yield LoadPerformanceReviews(pipeline=self.pipeline_name)
+        yield LoadEmployeeLeaveBalances(pipeline=self.pipeline_name)
 
 
 class UpdateLibHRData(HRQBPipelineTask):

--- a/hrqb/tasks/sql/employee_leave_balances.sql
+++ b/hrqb/tasks/sql/employee_leave_balances.sql
@@ -1,0 +1,28 @@
+/*
+Query for Employee Leave Balances.
+
+CHANGELOG
+    - 2024-09-26 Query created and added
+    - 2024-09-26 Filter to employees with appointment end dates >= 2019
+*/
+
+select
+    b.MIT_ID,
+    bt.ABSENCE_BALANCE_TYPE as BALANCE_TYPE,
+    b.BEGINNING_BALANCE_HOURS,
+    b.DEDUCTED_HOURS,
+    b.ENDING_BALANCE_HOURS,
+    b.BEGINNING_BALANCE_DAYS,
+    b.DEDUCTED_DAYS,
+    b.ENDING_BALANCE_DAYS,
+    b.ABSENCE_BALANCE_BEGIN_DATE,
+    b.ABSENCE_BALANCE_END_DATE
+from HR_ABSENCE_BALANCE b
+inner join HR_ABSENCE_BALANCE_TYPE bt on b.HR_ABSENCE_BALANCE_TYPE_KEY = bt.HR_ABSENCE_BALANCE_TYPE_KEY
+where bt.ABSENCE_BALANCE_TYPE != 'N/A'
+and b.MIT_ID in (
+    select
+        a.MIT_ID
+    from HR_APPOINTMENT_DETAIL a
+    where a.APPT_END_DATE >= TO_DATE('2019-01-01', 'YYYY-MM-DD')
+)

--- a/tests/tasks/test_employee_leave.py
+++ b/tests/tasks/test_employee_leave.py
@@ -42,7 +42,7 @@ def test_task_transform_employee_leave_key_expected_from_row_data(
     )
 
 
-def test_task_load_employee_salary_history_explicit_properties(
+def test_task_load_employee_leave_explicit_properties(
     task_load_employee_leave,
 ):
     assert task_load_employee_leave.merge_field == "Key"

--- a/tests/tasks/test_employee_leave_balances.py
+++ b/tests/tasks/test_employee_leave_balances.py
@@ -1,0 +1,33 @@
+from hrqb.utils import md5_hash_from_values
+
+
+def test_extract_dw_employee_leave_balances_load_sql_query(
+    task_extract_dw_employee_leave_balances_complete,
+):
+    assert (
+        task_extract_dw_employee_leave_balances_complete.sql_file
+        == "hrqb/tasks/sql/employee_leave_balances.sql"
+    )
+    assert task_extract_dw_employee_leave_balances_complete.sql_query is not None
+
+
+def test_task_transform_employee_leave_balances_key_expected_from_row_data(
+    task_transform_employee_leave_balance_complete,
+):
+    row = task_transform_employee_leave_balance_complete.get_dataframe().iloc[0]
+    assert row["Key"] == md5_hash_from_values(
+        [
+            row["MIT ID"],
+            row["Balance Type"],
+        ]
+    )
+
+
+def test_task_load_employee_leave_balances_explicit_properties(
+    task_load_employee_leave_balances,
+):
+    assert task_load_employee_leave_balances.merge_field == "Key"
+    assert (
+        task_load_employee_leave_balances.input_task_to_load
+        == "TransformEmployeeLeaveBalances"
+    )


### PR DESCRIPTION
### Purpose and background context

This PR adds a new task suite under `tasks.employee_leave_balances` that loads data into a new Quickbase table `Employee Leave Balances`.

This is arguably one of the simpler HRQB tasks and tables to load: minimal transformation needed, mostly just dovetailing with naming conventions and preparing for Quickbase.

### How can a reviewer manually see the effects of these changes?

Not available.  The [test fixture `conftest.task_extract_dw_employee_leave_balances_complete`](https://github.com/MITLibraries/hrqb-client/pull/185/files#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R1009-R1025) shows the structure of the data pulled from the warehouse, and how it's structured for loading into Quickbase.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/HRQB-51

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes

