### PR TITLE
Remove end date as part of appointment unique key

### DIFF
--- a/hrqb/tasks/employee_appointments.py
+++ b/hrqb/tasks/employee_appointments.py
@@ -104,7 +104,6 @@ class TransformEmployeeAppointments(PandasPickleTask):
                 row.mit_id,
                 row.position_id,
                 row.appt_begin_date,
-                row.appt_end_date,
             ),
             axis=1,
         )
@@ -139,14 +138,12 @@ class TransformEmployeeAppointments(PandasPickleTask):
         mit_id: str,
         position_id: str,
         appt_begin_date: str,
-        appt_end_date: str,
     ) -> str:
         return md5_hash_from_values(
             [
                 mit_id,
                 position_id,
                 appt_begin_date,
-                appt_end_date,
             ]
         )
 

--- a/hrqb/tasks/employee_leave.py
+++ b/hrqb/tasks/employee_leave.py
@@ -56,7 +56,6 @@ class TransformEmployeeLeave(PandasPickleTask):
                 row.mit_id,
                 row.position_id,
                 row.appt_begin_date,
-                row.appt_end_date,
             ),
             axis=1,
         )

--- a/hrqb/tasks/employee_salary_history.py
+++ b/hrqb/tasks/employee_salary_history.py
@@ -50,7 +50,6 @@ class TransformEmployeeSalaryHistory(PandasPickleTask):
                 row.mit_id,
                 row.position_id,
                 row.appt_begin_date,
-                row.appt_end_date,
             ),
             axis=1,
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -790,7 +790,7 @@ def task_shared_extract_qb_employee_appointments_complete(all_tasks_pipeline_nam
                     "Related Employee Type": "Admin Staff",
                     "Union Name": "Le Union",
                     "Exempt / NE": "E",
-                    "Key": "868ce513323c5391ae8afaa0ceb70c69",
+                    "Key": "00f6099d6777bd9b6985bf86eeb3e449",
                 }
             ]
         )

--- a/tests/tasks/test_employee_appointments.py
+++ b/tests/tasks/test_employee_appointments.py
@@ -102,6 +102,5 @@ def test_task_transform_employee_appointments_key_expected_from_row_data(
             row["MIT ID"],
             row["Position ID"],
             row["Begin Date"],
-            row["End Date"],
         ]
     )


### PR DESCRIPTION
### Purpose and background context

An `Employee Appointment` end date was used as part of its enduring unique key in Quickbase, but this was flawed.  When an appointment ended, the end date was changed from `2999-12-31` to the actual end date, changing the unique key, and effectively leaving an extra row in Quickbase.

By removing the end date as part of the employee appointment key, we get an enduringly unique key that can be used for updates to pre-existing rows (e.g. the end date changes).

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- None

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes

