### PR TITLE
IN 1200 - Remove 2019 data cutoff

### DIFF
--- a/hrqb/tasks/sql/employee_appointments.sql
+++ b/hrqb/tasks/sql/employee_appointments.sql
@@ -11,6 +11,7 @@ CHANGELOG
     - 2024-05-13 Query created and added
     - 2024-06-03 Limit rows to appointments that end on or before 2019-01-01
     - 2024-06-05 Do not filter on benefits types
+    - 2025-02-05 Remove 2019-01-01 date cutoff entirely
 */
 
 select distinct
@@ -61,5 +62,4 @@ left join HR_POSITION p on p.HR_POSITION_KEY = a.HR_POSITION_KEY
 left join BENEFITS_ELIGIBILITY_CURRENT bec on
     bec.MIT_ID = a.MIT_ID
     and a.PERSONNEL_KEY = bec.PERSONNEL_KEY
-where a.APPT_END_DATE >= TO_DATE('2019-01-01', 'YYYY-MM-DD')
 order by a.MIT_ID, a.APPT_BEGIN_DATE, a.APPT_END_DATE

--- a/hrqb/tasks/sql/employee_leave.sql
+++ b/hrqb/tasks/sql/employee_leave.sql
@@ -4,6 +4,7 @@ Query for Employee Leaves.
 CHANGELOG
     - 2024-05-13 Query created and added
     - 2024-07-23 Added HR_POSITION.POSITION ID to select
+    - 2025-02-05 Remove 2019-01-01 date cutoff entirely
 */
 
 select distinct
@@ -25,8 +26,5 @@ from HR_ABSENCE_DETAIL abse
 inner join HR_APPOINTMENT_DETAIL appt on abse.MIT_ID = appt.MIT_ID
 inner join HR_ABSENCE_TYPE at on at.HR_ABSENCE_TYPE_KEY = abse.HR_ABSENCE_TYPE_KEY
 left join HR_POSITION p on p.HR_POSITION_KEY = appt.HR_POSITION_KEY
-where (
-    appt.APPT_END_DATE >= TO_DATE('2019-01-01', 'YYYY-MM-DD')
-    and abse.ABSENCE_DATE between appt.APPT_BEGIN_DATE and appt.APPT_END_DATE
-)
+where abse.ABSENCE_DATE between appt.APPT_BEGIN_DATE and appt.APPT_END_DATE
 order by appt.MIT_ID, abse.ABSENCE_DATE

--- a/hrqb/tasks/sql/employee_leave_balances.sql
+++ b/hrqb/tasks/sql/employee_leave_balances.sql
@@ -4,6 +4,7 @@ Query for Employee Leave Balances.
 CHANGELOG
     - 2024-09-26 Query created and added
     - 2024-09-26 Filter to employees with appointment end dates >= 2019
+    - 2025-02-05 Remove 2019-01-01 date cutoff entirely
 */
 
 select
@@ -24,5 +25,4 @@ and b.MIT_ID in (
     select
         a.MIT_ID
     from HR_APPOINTMENT_DETAIL a
-    where a.APPT_END_DATE >= TO_DATE('2019-01-01', 'YYYY-MM-DD')
 )

--- a/hrqb/tasks/sql/employee_salary_history.sql
+++ b/hrqb/tasks/sql/employee_salary_history.sql
@@ -10,6 +10,7 @@ CHANGELOG
     - 2024-06-03 Date limit to appointments ending after 2019-01-01
     - 2024-07-24 Added appointment begin/end date to help match appointments
     - 2024-09-18 Omit any HR_PERSONNEL_ACTION_TYPE rows where type is "Salary Supplement"
+    - 2025-02-05 Remove 2019-01-01 date cutoff entirely
 */
 
 select distinct
@@ -45,6 +46,5 @@ inner join HR_APPOINTMENT_DETAIL appt on appt.HR_APPT_KEY = a.HR_APPT_KEY
 left join HR_PERSONNEL_ACTION_TYPE at on at.HR_PERSONNEL_ACTION_TYPE_KEY = a.HR_PERSONNEL_ACTION_TYPE_KEY
 left join HR_JOB j on j.HR_JOB_KEY = a.HR_JOB_KEY
 left join HR_POSITION p on p.HR_POSITION_KEY = a.HR_POSITION_KEY
-where a.APPT_END_DATE >= TO_DATE('2019-01-01', 'YYYY-MM-DD')
-and at.HR_PERSONNEL_ACTION not in ('Salary Supplement')
+where at.HR_PERSONNEL_ACTION not in ('Salary Supplement')
 order by a.MIT_ID, a.APPT_TX_BEGIN_DATE, a.APPT_TX_END_DATE


### PR DESCRIPTION
### Purpose and background context

It was determined that filtering data older than `2019-01-01` is not needed and should no longer be performed by the data loader.

How this addresses that need:
* Removes SQL filtering for `2019-01-01`
* Filtering for more recent data will be done client-side in Quickbase

### How can a reviewer manually see the effects of these changes?

Not possible at this time.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
NO

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/IN-1200

### Developer
- [X] All new ENV is documented in README
- [X] All new ENV has been added to staging and production environments
- [X] All related Jira tickets are linked in commit message(s)
- [X] Stakeholder approval has been confirmed (or is not needed)

### Code Reviewer(s)
- [ ] The commit message is clear and follows our guidelines (not just this PR message)
- [ ] There are appropriate tests covering any new functionality
- [ ] The provided documentation is sufficient for understanding any new functionality introduced
- [ ] Any manual tests have been performed **or** provided examples verified
- [ ] New dependencies are appropriate or there were no changes

