### PR TITLE
IN 1450 - Refine logic for Employee Salary History unique key

### DIFF
--- a/hrqb/tasks/employee_salary_history.py
+++ b/hrqb/tasks/employee_salary_history.py
@@ -82,8 +82,6 @@ class TransformEmployeeSalaryHistory(PandasPickleTask):
                     row.mit_id,
                     row.position_id,
                     str(row.appointment_begin_date),
-                    str(row.hr_personnel_action),
-                    str(row.hr_action_reason),
                     str(row.start_date),
                 ]
             ),

--- a/hrqb/tasks/sql/employee_salary_history.sql
+++ b/hrqb/tasks/sql/employee_salary_history.sql
@@ -11,6 +11,7 @@ CHANGELOG
     - 2024-07-24 Added appointment begin/end date to help match appointments
     - 2024-09-18 Omit any HR_PERSONNEL_ACTION_TYPE rows where type is "Salary Supplement"
     - 2025-02-05 Remove 2019-01-01 date cutoff entirely
+    - 2025-09-04 Omit any HR_ACTION_REASON rows where reason is "Lump Sum"
 */
 
 select distinct
@@ -47,4 +48,5 @@ left join HR_PERSONNEL_ACTION_TYPE at on at.HR_PERSONNEL_ACTION_TYPE_KEY = a.HR_
 left join HR_JOB j on j.HR_JOB_KEY = a.HR_JOB_KEY
 left join HR_POSITION p on p.HR_POSITION_KEY = a.HR_POSITION_KEY
 where at.HR_PERSONNEL_ACTION not in ('Salary Supplement')
+and at.HR_ACTION_REASON not in ('Lump Sum')
 order by a.MIT_ID, a.APPT_TX_BEGIN_DATE, a.APPT_TX_END_DATE

--- a/tests/tasks/test_employee_salary_history.py
+++ b/tests/tasks/test_employee_salary_history.py
@@ -58,8 +58,6 @@ def test_task_transform_employee_salary_history_key_expected_from_input_data(
             emp_salary_row["MIT ID"],
             qb_emp_appt_row["Position ID"],
             qb_emp_appt_row["Begin Date"],
-            emp_salary_row["Related Salary Change Type"],
-            emp_salary_row["Salary Change Reason"],
             emp_salary_row["Start Date"],
         ]
     )


### PR DESCRIPTION
### Purpose and background context

Why these changes are being introduced:

A [recently added integrity test](https://github.com/MITLibraries/hrqb-client/pull/208/files#diff-841bf57450a05e6332b375cec602b5db7b7fc677a8640ccdf1b74225fa3bbe4bR221-R248) triggered for the `Employee Salary History` table, indicating we had a row in Quickbase that no longer aligned with data warehouse data.  As has happened before, it appears to be shifting data warehouse values, this time for "End Date" and reason and type data, which then modifies the unique key.  When the unique key changes, we get stale data in Quickbase because we are _adding_ rows instead of _updating_ them.

How this addresses that need:

After some analysis, and discussion with HR, it was determined we could remove some fields from the unique key logic which keeps it consistent between data warehouse changes.  Part of this work was also skipping any salary history with a reason of `"Lump Sum"` which has only showed up once across all employess / all time.   By removing that, the combination of `(MIT ID, Position ID, Start Date)` is unique across all salary history rows for all employees.  Similarly, we already skip "Supplemental Pay" for this reason.

In summary, this PR is very similar to past PRs where we needed to refine the merge field / unique key for a table when new data types and patterns were encountered from data warehouse data.  In almost all cases, it has required removing "end dates" (broadly speaking) so that when the "end date" of something changes, it does not modify the calculation of the unique key.

### Includes new or updated dependencies?
NO

### Changes expectations for external applications?
YES:  the `Employee Salary History` table will be truncated + repopulated (as we have done for other merge field changes)

### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/IN-1450